### PR TITLE
fix: move Gemini API key from URL query param to x-goog-api-key header

### DIFF
--- a/lib/services/ai/gemini_api_client.dart
+++ b/lib/services/ai/gemini_api_client.dart
@@ -134,8 +134,11 @@ class GeminiApiClient {
 
     try {
       final response = await postWithRetry(
-        Uri.parse('$_apiUrl?key=$_apiKey'),
-        headers: {'Content-Type': 'application/json'},
+        Uri.parse(_apiUrl),
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': _apiKey,
+        },
         body: jsonEncode({
           'contents': [
             {'parts': parts, 'role': 'user'},


### PR DESCRIPTION
## Summary

- Gemini API キーが URL クエリパラメータ (`?key=...`) として送信されていたため、デバイスログやクラッシュレポートに露出するリスクがあった
- API キーを Google 標準の HTTP ヘッダー (`x-goog-api-key`) に移行し、URL からキーを完全に除去

## Test Plan

- `fvm flutter analyze` — No issues found を確認済み
- `fvm flutter test test/unit/services/ai/` — 193 tests passed を確認済み
- CodeRabbit レビュー — No findings を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * AI APIとの通信方式を改善しました。セキュリティと互換性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->