### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/lib/services/storage_export_delegate.dart
+++ b/lib/services/storage_export_delegate.dart
@@ -67,7 +67,7 @@ class StorageExportDelegate {
     final fileName =
         'smart_diary_backup_${DateTime.now().millisecondsSinceEpoch}.json';
     final l10n = LocalizationUtils.resolveFor(await _resolveLocale());
-    final outputFile = await FilePicker.platform.saveFile(
+    final outputFile = await FilePicker.saveFile(
       dialogTitle: l10n.settingsBackupDialogTitle,
       fileName: fileName,
       type: FileType.custom,

--- a/lib/services/storage_import_delegate.dart
+++ b/lib/services/storage_import_delegate.dart
@@ -27,7 +27,7 @@ class StorageImportDelegate {
     try {
       // ファイル選択
       final l10n = LocalizationUtils.resolveFor(await _resolveLocale());
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['json'],
         dialogTitle: l10n.settingsRestoreDialogTitle,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -137,14 +137,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -157,10 +149,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b8fe52979ff12432ecf8f0abf6ff70410b1bb734be1c9e4f2f86807ad7166c79
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -245,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.2"
   file_selector_linux:
     dependency: transitive
     description:
@@ -298,10 +290,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_dotenv
-      sha256: d4130c4a43e0b13fefc593bc3961f2cb46e30cb79e253d4a526b1b5d24ae1ce4
+      sha256: d41da11fb497314fbf89811ec30af02d1d898b47980a129f0a8c0a1720460ba2
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -401,10 +393,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.1.0"
   graphs:
     dependency: transitive
     description:
@@ -689,10 +681,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,15 +42,15 @@ dependencies:
   photo_manager: ^3.7.1
   permission_handler: ^12.0.0+1
   http: ^1.1.0
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^7.1.1
   intl: ^0.20.0
-  flutter_dotenv: ^6.0.0
+  flutter_dotenv: ^6.0.1
   uuid: ^4.5.1
   table_calendar: ^3.1.2
   shared_preferences: ^2.3.2
   package_info_plus: ^9.0.0
-  file_picker: ^10.2.0
-  google_fonts: ^8.0.2
+  file_picker: ^11.0.2
+  google_fonts: ^8.1.0
   image_picker: ^1.0.7
   in_app_purchase: ^3.2.3
   url_launcher: ^6.1.14
@@ -76,8 +76,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   lints: ^6.1.0
-  mocktail: ^1.0.4
-  build_runner: ^2.12.2
+  mocktail: ^1.0.5
+  build_runner: ^2.15.0
   hive_ce_generator: ^1.11.1
   flutter_launcher_icons: ^0.14.4
 


### PR DESCRIPTION
## Summary
- `connectivity_plus` 7.1.0 → 7.1.1
- `google_fonts` 8.0.2 → 8.1.0
- `flutter_dotenv` 6.0.0 → 6.0.1
- `file_picker` 10.3.10 → 11.0.2 — fixes CWE-22 path traversal vulnerability on Android
- `build_runner` 2.13.1 → 2.15.0
- `mocktail` 1.0.4 → 1.0.5
- Migrate `FilePicker.platform.*` calls to static methods per file_picker v11 breaking change

## Test Plan
- `fvm flutter analyze` — No issues found
- `fvm flutter test` — 1783 tests passed