### PR TITLE
refactor: eliminate code duplication and guard spurious notifyListeners calls

### DIFF
--- a/lib/controllers/photo_selection_controller.dart
+++ b/lib/controllers/photo_selection_controller.dart
@@ -169,18 +169,21 @@ class PhotoSelectionController extends ChangeNotifier {
 
   /// ローディング状態を設定
   void setLoading(bool loading) {
+    if (_isLoading == loading) return;
     _isLoading = loading;
     notifyListeners();
   }
 
   /// 権限状態を設定
   void setPermission(bool permission) {
+    if (_hasPermission == permission) return;
     _hasPermission = permission;
     notifyListeners();
   }
 
   /// 追加写真存在フラグを設定
   void setHasMorePhotos(bool hasMore) {
+    if (_hasMorePhotos == hasMore) return;
     _hasMorePhotos = hasMore;
     notifyListeners();
   }

--- a/lib/localization/localization_extensions.dart
+++ b/lib/localization/localization_extensions.dart
@@ -22,6 +22,10 @@ extension LocalizationFormattingX on AppLocalizations {
   String formatMonthDay(DateTime date) =>
       DateFormat.Md(localeName).format(date);
 
+  /// 例: SEP 20 · SATURDAY (大文字、日記カード/詳細ヘッダー用)
+  String formatMonthDayWithDayName(DateTime date) =>
+      DateFormat('MMM d · EEEE', localeName).format(date).toUpperCase();
+
   /// 例: 9月20日 / September 20
   String formatMonthDayLong(DateTime date) =>
       DateFormat.MMMMd(localeName).format(date);

--- a/lib/screens/diary_detail/diary_detail_content.dart
+++ b/lib/screens/diary_detail/diary_detail_content.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 import '../../constants/app_constants.dart';
@@ -69,13 +68,8 @@ class _DiaryDetailContentState extends State<DiaryDetailContent> {
     }
   }
 
-  String _computeDateLabel() {
-    final locale = Localizations.localeOf(context).toString();
-    return DateFormat(
-      'MMM d · EEEE',
-      locale,
-    ).format(widget.diaryEntry.date).toUpperCase();
-  }
+  String _computeDateLabel() =>
+      context.l10n.formatMonthDayWithDayName(widget.diaryEntry.date);
 
   Future<Result<Uint8List>> _getGalleryThumbnail(AssetEntity asset) {
     return _galleryFutures.putIfAbsent(

--- a/lib/services/diary_service.dart
+++ b/lib/services/diary_service.dart
@@ -19,7 +19,7 @@ import 'diary_query_delegate.dart';
 /// インデックス管理はDiaryIndexManagerに、タグ管理はIDiaryTagServiceに、
 /// 統計はIDiaryStatisticsServiceに委譲。
 class DiaryService implements IDiaryService {
-  static const String _boxName = 'diary_entries';
+  static const String diaryEntriesBoxName = 'diary_entries';
   Box<DiaryEntry>? _diaryBox;
   final ILoggingService _loggingService;
   final HiveAesCipher? _encryptionCipher;
@@ -118,7 +118,7 @@ class DiaryService implements IDiaryService {
       }
 
       _diaryBox = await Hive.openBox<DiaryEntry>(
-        _boxName,
+        diaryEntriesBoxName,
         encryptionCipher: _encryptionCipher,
       );
       _loggingService.info(
@@ -141,19 +141,21 @@ class DiaryService implements IDiaryService {
   Future<void> _migrateToEncrypted(Box metaBox) async {
     try {
       // 未暗号化で開いてデータを読み出す
-      final unencryptedBox = await Hive.openBox<DiaryEntry>(_boxName);
+      final unencryptedBox = await Hive.openBox<DiaryEntry>(
+        diaryEntriesBoxName,
+      );
       final entries = unencryptedBox.toMap();
       _loggingService.info(
         'Starting encryption migration: ${entries.length} entries found',
       );
       await unencryptedBox.close();
-      await Hive.deleteBoxFromDisk(_boxName);
+      await Hive.deleteBoxFromDisk(diaryEntriesBoxName);
 
       // 暗号化ボックスに書き込み
       // NOTE: HiveObjectは元のボックスへの参照を持つため、
       // copyWith()で新しいインスタンスを作成してから書き込む
       _diaryBox = await Hive.openBox<DiaryEntry>(
-        _boxName,
+        diaryEntriesBoxName,
         encryptionCipher: _encryptionCipher,
       );
       await _diaryBox!.putAll(entries.map((k, v) => MapEntry(k, v.copyWith())));
@@ -173,10 +175,10 @@ class DiaryService implements IDiaryService {
   /// スキーマ不整合時のみボックスを削除して再作成する
   Future<void> _recreateBox() async {
     try {
-      await Hive.deleteBoxFromDisk(_boxName);
+      await Hive.deleteBoxFromDisk(diaryEntriesBoxName);
       _loggingService.warning('Old box deleted');
       _diaryBox = await Hive.openBox<DiaryEntry>(
-        _boxName,
+        diaryEntriesBoxName,
         encryptionCipher: _encryptionCipher,
       );
       _loggingService.info('New box created');

--- a/lib/services/diary_statistics_service.dart
+++ b/lib/services/diary_statistics_service.dart
@@ -1,5 +1,6 @@
 import 'package:hive_ce/hive_ce.dart';
 import '../models/diary_entry.dart';
+import 'diary_service.dart';
 import 'interfaces/diary_statistics_service_interface.dart';
 import 'interfaces/logging_service_interface.dart';
 import '../core/result/result.dart';
@@ -10,7 +11,7 @@ import '../core/errors/app_exceptions.dart';
 /// 日記の総数・期間別カウントなどの統計情報を提供。
 /// Hiveボックスは遅延取得（DiaryServiceが先にオープン済みを前提）。
 class DiaryStatisticsService implements IDiaryStatisticsService {
-  static const String _boxName = 'diary_entries';
+  static const String _boxName = DiaryService.diaryEntriesBoxName;
 
   final ILoggingService _logger;
 

--- a/lib/services/diary_tag_service.dart
+++ b/lib/services/diary_tag_service.dart
@@ -9,13 +9,14 @@ import 'interfaces/settings_service_interface.dart';
 import '../core/service_registration.dart';
 import '../core/result/result.dart';
 import '../core/errors/app_exceptions.dart';
+import 'diary_service.dart';
 
 /// 日記タグ管理サービス
 ///
 /// タグの取得（AI生成/キャッシュ）、全タグ集計、人気タグ集計、
 /// バックグラウンドタグ生成を担当。
 class DiaryTagService implements IDiaryTagService {
-  static const String _boxName = 'diary_entries';
+  static const String _boxName = DiaryService.diaryEntriesBoxName;
 
   final IAiService _aiService;
   final ILoggingService _logger;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -40,13 +40,8 @@ class SettingsService implements ISettingsService {
     );
   }
 
-  // 日記の長さ設定のキー
   static const String _diaryLengthKey = 'diary_length';
-
-  // テーマ設定のキー
   static const String _themeKey = 'theme_mode';
-
-  // 初回起動フラグのキー
   static const String _firstLaunchKey = 'is_first_launch';
 
   @override

--- a/lib/widgets/diary_card_widget.dart
+++ b/lib/widgets/diary_card_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:photo_manager/photo_manager.dart';
 import '../constants/app_constants.dart';
 import '../core/result/result.dart';
@@ -63,13 +62,8 @@ class _DiaryCardWidgetState extends State<DiaryCardWidget> {
     _photoAssetsFuture = _fetchPhotoAssets();
   }
 
-  String _computeHeroDate() {
-    final locale = Localizations.localeOf(context);
-    return DateFormat(
-      'MMM d · EEEE',
-      locale.toString(),
-    ).format(widget.entry.date).toUpperCase();
-  }
+  String _computeHeroDate() =>
+      context.l10n.formatMonthDayWithDayName(widget.entry.date);
 
   Future<List<AssetEntity>> _fetchPhotoAssets() {
     if (widget.entry.photoIds.isEmpty) {


### PR DESCRIPTION
## Summary
- Extract `'diary_entries'` Hive box name to `DiaryService.diaryEntriesBoxName` — previously duplicated as a magic string in 3 separate service files (`DiaryService`, `DiaryStatisticsService`, `DiaryTagService`)
- Add `formatMonthDayWithDayName()` to `LocalizationFormattingX` extension and replace identical inline `DateFormat('MMM d · EEEE', ...).toUpperCase()` calls in `DiaryCardWidget` and `DiaryDetailContent`; removes two now-unused `intl` imports
- Guard `setLoading()`, `setPermission()`, and `setHasMorePhotos()` in `PhotoSelectionController` with equality checks to skip `notifyListeners()` when state is unchanged — prevents spurious rebuilds of timeline tiles
- Remove 3 comments in `settings_service.dart` that restate what the constant names already express

## Test Plan
- `fvm flutter analyze` — no issues
- `fvm flutter test` — 1783 tests, all passing