### PR TITLE
feat: replace loading cards with skeleton preview screen during diary generation

### DIFF
--- a/design_handoff/generating-screen.jsx
+++ b/design_handoff/generating-screen.jsx
@@ -1,0 +1,518 @@
+// GeneratingScreen — the screen shown while the AI composes the diary
+// entry. Three takes on the same content (photos, prompt, status) that
+// inherit the Hero language used across the redesigned app: editorial
+// hero photo, ACCENT eyebrow → bold headline, no per-section CustomCard
+// chrome, tag-style filled chips, hairline dividers.
+//
+// Variants
+//   A · Calm editorial    — quietest, single slim progress bar.
+//   B · Staged             — vertical stage list (read → sense → compose
+//                            → polish) with current step pulsing.
+//   C · Skeleton preview   — shows where the finished entry will appear,
+//                            with shimmering placeholders.
+
+// ─── one-time keyframes injection ──────────────────────────────
+if (typeof document !== 'undefined' && !document.getElementById('gen-styles')) {
+  const s = document.createElement('style');
+  s.id = 'gen-styles';
+  s.textContent = [
+    '@keyframes gen-shimmer{0%{background-position:-220px 0}100%{background-position:220px 0}}',
+    '@keyframes gen-pulse{0%,100%{opacity:.6}50%{opacity:1}}',
+    '@keyframes gen-indet{0%{transform:translateX(-100%)}100%{transform:translateX(220%)}}',
+    '@keyframes gen-dot{0%,80%,100%{opacity:.25;transform:translateY(0)}',
+    '  40%{opacity:1;transform:translateY(-2px)}}',
+    '.gen-shimmer{background:linear-gradient(90deg,',
+    '  var(--gen-shimmer-base) 0%, var(--gen-shimmer-hi) 50%, var(--gen-shimmer-base) 100%);',
+    '  background-size:220px 100%;background-repeat:no-repeat;',
+    '  background-color:var(--gen-shimmer-base);',
+    '  animation:gen-shimmer 1.4s linear infinite}',
+    '.gen-pulse{animation:gen-pulse 1.6s ease-in-out infinite}',
+    '.gen-indet{animation:gen-indet 1.4s cubic-bezier(.4,0,.2,1) infinite}',
+    '.gen-dot{display:inline-block;animation:gen-dot 1.2s ease-in-out infinite}',
+    '.gen-dot:nth-child(2){animation-delay:.15s}',
+    '.gen-dot:nth-child(3){animation-delay:.3s}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+// ─── icons (kept local to avoid load-order coupling) ───────────
+function GenIconBack({ c, s = 22 }) { return (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none">
+    <path d="M15 6l-6 6 6 6" stroke={c} strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);}
+function GenIconCheck({ c, s = 14 }) { return (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none">
+    <path d="M5 12l4.5 4.5L19 7" stroke={c} strokeWidth="2.4"
+      strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);}
+function GenIconSparkle({ c, s = 14 }) { return (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none">
+    <path d="M12 3l1.6 4.4 4.4 1.6-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
+      stroke={c} strokeWidth="1.6" strokeLinejoin="round"/>
+    <path d="M19 15.5l.7 1.8 1.8.7-1.8.7L19 20.5l-.7-1.8-1.8-.7 1.8-.7L19 15.5z"
+      fill={c}/>
+  </svg>
+);}
+
+// ─── shared bits ───────────────────────────────────────────────
+function GenAppBar({ tokens, label }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', height: 56,
+      padding: '8px 8px 8px 8px', background: 'transparent',
+      position: 'relative',
+    }}>
+      <button style={{
+        width: 44, height: 44, borderRadius: 12, border: 'none',
+        background: 'transparent', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: tokens.title,
+      }}>
+        <GenIconBack c={tokens.title}/>
+      </button>
+      {label && (
+        <div style={{
+          position: 'absolute', left: 0, right: 0, textAlign: 'center',
+          pointerEvents: 'none',
+          fontSize: 11, fontWeight: 700, letterSpacing: 1,
+          textTransform: 'uppercase', color: tokens.accentMuted,
+        }}>{label}</div>
+      )}
+    </div>
+  );
+}
+
+// Indeterminate slim track. Used in A and B; C uses a thicker variant.
+function GenProgressTrack({ tokens, thick = false }) {
+  const isDark = tokens === window.darkTokens;
+  return (
+    <div style={{
+      width: '100%', height: thick ? 4 : 3,
+      borderRadius: 999, overflow: 'hidden',
+      background: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(35,30,26,0.06)',
+      position: 'relative',
+    }}>
+      <div className="gen-indet" style={{
+        position: 'absolute', top: 0, bottom: 0, width: '45%',
+        borderRadius: 999, background: tokens.accentMuted,
+      }}/>
+    </div>
+  );
+}
+
+function GenDateLine({ tokens, date, dayOfWeek }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      fontSize: 12, fontWeight: 700, letterSpacing: 0.8,
+      textTransform: 'uppercase', color: tokens.accentMuted,
+    }}>
+      <span>{date}</span>
+      <span style={{ width: 3, height: 3, borderRadius: 999,
+        background: tokens.accentMuted, opacity: 0.5 }}/>
+      <span style={{ color: tokens.muted, fontWeight: 600, letterSpacing: 0.4 }}>
+        {dayOfWeek}
+      </span>
+    </div>
+  );
+}
+
+// Animated three-dot tail for headline ("Writing your diary").
+function GenDots({ tokens }) {
+  return (
+    <span style={{ marginLeft: 2, color: tokens.accentMuted, fontWeight: 700 }}>
+      <span className="gen-dot">.</span>
+      <span className="gen-dot">.</span>
+      <span className="gen-dot">.</span>
+    </span>
+  );
+}
+
+// ─── sample data ───────────────────────────────────────────────
+const GEN_DEFAULT = {
+  date: 'MAY 16, 2026',
+  dayOfWeek: 'Saturday',
+  promptCategory: 'Emotion',
+  promptText: 'What was the very first feeling that surfaced in this moment?',
+  photos: [
+    'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=800&q=80&auto=format&fit=crop',
+    'https://images.unsplash.com/photo-1573865526739-10659fec78a5?w=800&q=80&auto=format&fit=crop',
+    'https://images.unsplash.com/photo-1543852786-1cf6624b9987?w=800&q=80&auto=format&fit=crop',
+  ],
+  photoCount: 3,
+};
+
+// ════════════════════════════════════════════════════════════════
+// Variant A · Calm editorial
+// ════════════════════════════════════════════════════════════════
+function GeneratingScreenEditorial({ tokens, data = GEN_DEFAULT, progress = 0.5 }) {
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
+      background: tokens.surface, color: tokens.title,
+      fontFamily: '"Noto Sans JP", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+    }}>
+      <div style={{ height: 54, flexShrink: 0 }}/>
+      <GenAppBar tokens={tokens}/>
+
+      <div style={{ flex: 1, padding: '4px 20px 0', overflow: 'hidden' }}>
+        {/* eyebrow + headline */}
+        <GenDateLine tokens={tokens} date={data.date} dayOfWeek={data.dayOfWeek}/>
+        <div style={{ height: 8 }}/>
+        <div style={{
+          fontSize: 26, fontWeight: 700, lineHeight: 1.22, letterSpacing: -0.3,
+          color: tokens.title, textWrap: 'pretty',
+        }}>
+          Writing your diary<GenDots tokens={tokens}/>
+        </div>
+
+        {/* prompt — quiet italic, no card */}
+        <div style={{ marginTop: 18,
+          paddingLeft: 14, borderLeft: `2px solid ${tokens.chipOutline}` }}>
+          <div style={{
+            fontSize: 10.5, fontWeight: 700, letterSpacing: 0.9,
+            textTransform: 'uppercase', color: tokens.muted, marginBottom: 4,
+          }}>Prompt · {data.promptCategory}</div>
+          <div style={{
+            fontSize: 14.5, lineHeight: 1.55, fontStyle: 'italic',
+            color: tokens.body || tokens.title, fontWeight: 400,
+            letterSpacing: 0.05,
+          }}>"{data.promptText}"</div>
+        </div>
+
+        {/* hairline */}
+        <div style={{ height: 1, background: tokens.divider, margin: '24px 0' }}/>
+
+        {/* selected photos — quiet strip, no card chrome */}
+        <div style={{
+          fontSize: 10.5, fontWeight: 700, letterSpacing: 0.9,
+          textTransform: 'uppercase', color: tokens.muted, marginBottom: 10,
+        }}>{data.photoCount} photo{data.photoCount > 1 ? 's' : ''} selected</div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {data.photos.slice(0, 4).map((p, i) => (
+            <div key={i} style={{
+              flex: 1, aspectRatio: '1 / 1', borderRadius: 10, overflow: 'hidden',
+              background: tokens.photoFallback, position: 'relative',
+              boxShadow: tokens.photoInner,
+            }}>
+              <img src={p} alt="" loading="lazy"
+                style={{ width: '100%', height: '100%', objectFit: 'cover',
+                  display: 'block', filter: 'saturate(0.92)' }}/>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* status footer — slim, anchored to the bottom */}
+      <div style={{ padding: '0 20px 20px' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          marginBottom: 8,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <GenIconSparkle c={tokens.accentMuted} s={14}/>
+            <span className="gen-pulse" style={{
+              fontSize: 13.5, fontWeight: 600, color: tokens.title,
+              letterSpacing: -0.1,
+            }}>Composing</span>
+          </div>
+          <div style={{
+            fontSize: 11.5, fontWeight: 600, color: tokens.muted,
+            letterSpacing: 0.3, fontVariantNumeric: 'tabular-nums',
+          }}>Step 3 of 4</div>
+        </div>
+        <GenProgressTrack tokens={tokens}/>
+      </div>
+      <div style={{ height: 24, flexShrink: 0 }}/>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// Variant B · Staged
+// ════════════════════════════════════════════════════════════════
+const GEN_STAGES = [
+  { id: 'read',    label: 'Reading 3 photos',  caption: 'Looking at what you captured.' },
+  { id: 'sense',   label: 'Sensing the mood',  caption: 'Light, colour, what stands out.' },
+  { id: 'compose', label: 'Composing',          caption: 'Drafting in your voice.' },
+  { id: 'polish',  label: 'Polishing',          caption: 'Title, tags, final pass.' },
+];
+
+function GenStageRow({ stage, status, tokens, last }) {
+  const isDark = tokens === window.darkTokens;
+  // completed → check disc in accentMuted
+  // active    → pulsing ring in accentMuted
+  // pending   → muted hollow disc
+  const accent = tokens.accentMuted;
+  let disc;
+  if (status === 'done') {
+    disc = (
+      <div style={{
+        width: 28, height: 28, borderRadius: 999,
+        background: isDark ? 'rgba(212,166,142,0.22)' : 'rgba(184,133,108,0.18)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <GenIconCheck c={accent} s={14}/>
+      </div>
+    );
+  } else if (status === 'active') {
+    disc = (
+      <div className="gen-pulse" style={{
+        width: 28, height: 28, borderRadius: 999,
+        background: accent,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow: `0 0 0 5px ${isDark ? 'rgba(212,166,142,0.18)' : 'rgba(184,133,108,0.14)'}`,
+      }}>
+        <GenIconSparkle c="#fff" s={14}/>
+      </div>
+    );
+  } else {
+    disc = (
+      <div style={{
+        width: 28, height: 28, borderRadius: 999,
+        border: `1.5px solid ${tokens.chipOutline}`,
+        background: 'transparent',
+      }}/>
+    );
+  }
+
+  const titleColor = status === 'pending' ? tokens.muted : tokens.title;
+  const titleWeight = status === 'active' ? 700 : 600;
+  return (
+    <div style={{ display: 'flex', gap: 14, position: 'relative' }}>
+      {/* connector */}
+      {!last && (
+        <div style={{
+          position: 'absolute', left: 14, top: 30, bottom: -22, width: 1.5,
+          background: tokens.divider,
+        }}/>
+      )}
+      <div style={{ flexShrink: 0, position: 'relative', zIndex: 1 }}>{disc}</div>
+      <div style={{ flex: 1, paddingTop: 1 }}>
+        <div style={{
+          fontSize: 15, fontWeight: titleWeight, color: titleColor,
+          letterSpacing: -0.1, lineHeight: 1.3,
+        }}>
+          {stage.label}
+          {status === 'active' && <GenDots tokens={tokens}/>}
+        </div>
+        <div style={{
+          fontSize: 12.5, color: tokens.muted, lineHeight: 1.45,
+          marginTop: 2,
+        }}>{stage.caption}</div>
+      </div>
+    </div>
+  );
+}
+
+function GeneratingScreenStaged({ tokens, data = GEN_DEFAULT, activeIndex = 2 }) {
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
+      background: tokens.surface, color: tokens.title,
+      fontFamily: '"Noto Sans JP", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+    }}>
+      <div style={{ height: 54, flexShrink: 0 }}/>
+      <GenAppBar tokens={tokens}/>
+
+      <div style={{ flex: 1, padding: '4px 20px 0', overflow: 'hidden' }}>
+        <GenDateLine tokens={tokens} date={data.date} dayOfWeek={data.dayOfWeek}/>
+        <div style={{ height: 8 }}/>
+        <div style={{
+          fontSize: 26, fontWeight: 700, lineHeight: 1.22, letterSpacing: -0.3,
+          color: tokens.title, textWrap: 'pretty',
+        }}>
+          Writing your diary<GenDots tokens={tokens}/>
+        </div>
+
+        {/* photo strip — anchors the user's selection without taking centre stage */}
+        <div style={{ display: 'flex', gap: 6, marginTop: 18 }}>
+          {data.photos.slice(0, 4).map((p, i) => (
+            <div key={i} style={{
+              width: 52, height: 52, borderRadius: 10, overflow: 'hidden',
+              background: tokens.photoFallback, boxShadow: tokens.photoInner,
+            }}>
+              <img src={p} alt="" loading="lazy"
+                style={{ width: '100%', height: '100%', objectFit: 'cover',
+                  display: 'block' }}/>
+            </div>
+          ))}
+          <div style={{
+            marginLeft: 'auto', alignSelf: 'flex-end',
+            fontSize: 11, fontWeight: 600, color: tokens.muted,
+            letterSpacing: 0.3,
+          }}>{data.photoCount} photos · {data.promptCategory.toLowerCase()} prompt</div>
+        </div>
+
+        {/* hairline */}
+        <div style={{ height: 1, background: tokens.divider, margin: '24px 0' }}/>
+
+        {/* stage list */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+          {GEN_STAGES.map((s, i) => (
+            <GenStageRow key={s.id} stage={s} tokens={tokens}
+              status={i < activeIndex ? 'done' : i === activeIndex ? 'active' : 'pending'}
+              last={i === GEN_STAGES.length - 1}/>
+          ))}
+        </div>
+      </div>
+
+      {/* progress at very bottom */}
+      <div style={{ padding: '0 20px 20px' }}>
+        <GenProgressTrack tokens={tokens}/>
+      </div>
+      <div style={{ height: 24, flexShrink: 0 }}/>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// Variant C · Skeleton preview
+// ════════════════════════════════════════════════════════════════
+function GenSkel({ w = '100%', h = 14, r = 6, tokens, style = {} }) {
+  const isDark = tokens === window.darkTokens;
+  return (
+    <div className="gen-shimmer" style={{
+      width: w, height: h, borderRadius: r,
+      '--gen-shimmer-base': isDark ? 'rgba(255,255,255,0.05)' : 'rgba(35,30,26,0.05)',
+      '--gen-shimmer-hi':   isDark ? 'rgba(255,255,255,0.10)' : 'rgba(35,30,26,0.09)',
+      ...style,
+    }}/>
+  );
+}
+
+function GeneratingScreenSkeleton({ tokens, data = GEN_DEFAULT }) {
+  const isDark = tokens === window.darkTokens;
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
+      background: tokens.surface, color: tokens.title,
+      fontFamily: '"Noto Sans JP", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+      position: 'relative',
+    }}>
+      <div style={{ height: 54, flexShrink: 0 }}/>
+
+      {/* hero photo (matches the detail screen layout exactly) */}
+      <div style={{ position: 'relative', width: '100%', aspectRatio: '4 / 3' }}>
+        <img src={data.photos[0]} alt="" loading="lazy"
+          style={{ width: '100%', height: '100%', objectFit: 'cover',
+            display: 'block', filter: 'saturate(0.9)' }}/>
+        {/* top scrim for AppBar legibility */}
+        <div style={{
+          position: 'absolute', top: 0, left: 0, right: 0, height: '45%',
+          background: 'linear-gradient(180deg, rgba(20,18,16,0.45) 0%, rgba(20,18,16,0) 100%)',
+          pointerEvents: 'none',
+        }}/>
+        {/* floating back button */}
+        <div style={{
+          position: 'absolute', top: -56, left: 0, right: 0,
+          height: 56, padding: '8px 8px 8px 8px',
+          display: 'flex', alignItems: 'center',
+        }}>
+          <div style={{
+            width: 36, height: 36, borderRadius: 999,
+            background: 'rgba(0,0,0,0.42)', backdropFilter: 'blur(10px)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            <GenIconBack c="#fff" s={20}/>
+          </div>
+        </div>
+        {/* photo count pill */}
+        {data.photoCount > 1 && (
+          <div style={{
+            position: 'absolute', right: 14, bottom: 14,
+            padding: '6px 12px', borderRadius: 999,
+            background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(10px)',
+            color: '#fff', fontSize: 12, fontWeight: 700,
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+          }}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+              <rect x="3" y="3" width="13" height="13" rx="2" stroke="#fff" strokeWidth="2"/>
+              <rect x="8" y="8" width="13" height="13" rx="2" stroke="#fff" strokeWidth="2"/>
+            </svg>
+            1 / {data.photoCount}
+          </div>
+        )}
+      </div>
+
+      {/* skeleton content area — mirrors detail screen */}
+      <div style={{ flex: 1, padding: '20px 20px 0', overflow: 'hidden' }}>
+        {/* date label (real, not skeleton — it's known) */}
+        <GenDateLine tokens={tokens} date={data.date} dayOfWeek={data.dayOfWeek}/>
+
+        {/* title shimmer */}
+        <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <GenSkel tokens={tokens} w="85%" h={22} r={6}/>
+          <GenSkel tokens={tokens} w="55%" h={22} r={6}/>
+        </div>
+
+        {/* tag chip shimmer (3-tone heights of real chips) */}
+        <div style={{ display: 'flex', gap: 6, marginTop: 16 }}>
+          <GenSkel tokens={tokens} w={70} h={22} r={6}/>
+          <GenSkel tokens={tokens} w={86} h={22} r={6}/>
+          <GenSkel tokens={tokens} w={58} h={22} r={6}/>
+        </div>
+
+        {/* hairline */}
+        <div style={{ height: 1, background: tokens.divider, margin: '20px 0' }}/>
+
+        {/* body shimmer lines */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <GenSkel tokens={tokens} w="100%" h={12} r={4}/>
+          <GenSkel tokens={tokens} w="96%"  h={12} r={4}/>
+          <GenSkel tokens={tokens} w="100%" h={12} r={4}/>
+          <GenSkel tokens={tokens} w="78%"  h={12} r={4}/>
+        </div>
+      </div>
+
+      {/* generating banner pinned above the home indicator */}
+      <div style={{ padding: '0 16px 16px' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          padding: '12px 14px',
+          background: isDark ? 'rgba(212,166,142,0.14)' : 'rgba(184,133,108,0.10)',
+          borderRadius: 14,
+          border: `0.5px solid ${isDark ? 'rgba(212,166,142,0.22)' : 'rgba(184,133,108,0.20)'}`,
+        }}>
+          <div className="gen-pulse" style={{
+            width: 28, height: 28, borderRadius: 999, background: tokens.accentMuted,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+          }}>
+            <GenIconSparkle c="#fff" s={14}/>
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              fontSize: 13.5, fontWeight: 700, color: tokens.title,
+              letterSpacing: -0.1, lineHeight: 1.25,
+            }}>Writing your diary<GenDots tokens={tokens}/></div>
+            <div style={{
+              fontSize: 11.5, color: tokens.muted, marginTop: 2,
+              letterSpacing: 0.2,
+            }}>Reading 3 photos · {data.promptCategory.toLowerCase()} prompt</div>
+          </div>
+        </div>
+        <div style={{ height: 10 }}/>
+        <GenProgressTrack tokens={tokens} thick={true}/>
+      </div>
+      <div style={{ height: 24, flexShrink: 0 }}/>
+    </div>
+  );
+}
+
+// ─── variant catalogue ─────────────────────────────────────────
+const GEN_VARIANTS = [
+  { id: 'editorial', label: 'A · Calm editorial', Screen: GeneratingScreenEditorial,
+    blurb: 'Quietest. Hero language, prompt as a quiet quote, slim progress bar at the bottom.' },
+  { id: 'staged',    label: 'B · Staged',          Screen: GeneratingScreenStaged,
+    blurb: 'Vertical stage list. The user sees what the AI is doing for the 1–3 seconds it runs.' },
+  { id: 'skeleton',  label: 'C · Skeleton preview', Screen: GeneratingScreenSkeleton,
+    blurb: 'Shows the detail-screen layout the entry will land in, with shimmering placeholders.' },
+];
+
+Object.assign(window, {
+  GeneratingScreenEditorial, GeneratingScreenStaged, GeneratingScreenSkeleton,
+  GEN_VARIANTS, GEN_DEFAULT,
+});

--- a/design_handoff/index.html
+++ b/design_handoff/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Smart Photo Diary — Diaries List redesign</title>
+<title>Smart Photo Diary — redesign canvas</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -30,6 +30,7 @@
 <script type="text/babel" src="home-screen.jsx"></script>
 <script type="text/babel" src="settings-screen.jsx"></script>
 <script type="text/babel" src="filter-sheet.jsx"></script>
+<script type="text/babel" src="generating-screen.jsx"></script>
 
 <script type="text/babel">
 
@@ -3255,6 +3256,420 @@ function FilterCodeCard() {
   );
 }
 
+// ─── Generating-screen notes card ─────────────────────────────
+function GeneratingNotesCard() {
+  const Bullet = ({ title, body }) => (
+    <div style={{ display: 'flex', gap: 14 }}>
+      <div style={{ width: 6, height: 6, borderRadius: 999, background: '#B8856C',
+        marginTop: 9, flexShrink: 0 }}/>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 700, color: '#2C2825', marginBottom: 2 }}>{title}</div>
+        <div style={{ fontSize: 13, lineHeight: 1.55, color: '#6B6560' }}>{body}</div>
+      </div>
+    </div>
+  );
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: '#FAF8F5', borderRadius: 18,
+      padding: 26, boxSizing: 'border-box', border: '0.5px solid rgba(0,0,0,0.05)',
+      display: 'flex', flexDirection: 'column', gap: 16,
+      fontFamily: '"Noto Sans JP", -apple-system, system-ui, sans-serif',
+    }}>
+      <div>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1,
+          textTransform: 'uppercase', color: '#8E6450', marginBottom: 6 }}>
+          Diary generation
+        </div>
+        <div style={{ fontSize: 22, fontWeight: 700, color: '#2C2825',
+          letterSpacing: -0.3, lineHeight: 1.25 }}>
+          One screen, no chrome stack
+        </div>
+      </div>
+      <Bullet title="The problem"
+        body="The current 'Diary preview' screen stacks four CustomCards with icon+title headers (Diary date, Current Prompt with category badge, Selected photos, then a card-in-a-card loading state). It looks like a form being submitted, not the few seconds before a personal entry appears."/>
+      <Bullet title="Hero language applied"
+        body="Same vocabulary used on detail / list / settings: ACCENT eyebrow → bold 26pt headline, hairline dividers replacing card chrome, slim accent-coloured progress instead of a CircularProgressIndicator in a card. Date moves to the small uppercase tier."/>
+      <Bullet title="A · Calm editorial"
+        body="Quietest take. Bold 'Writing your diary…' headline, the prompt as a quiet italic block-quote with a left-rule, the user's photos as a flat 4-up strip, and one slim indeterminate bar pinned to the bottom with a one-line status ('Composing · Step 3 of 4'). Reads as a moment of pause."/>
+      <Bullet title="B · Staged"
+        body="Vertical stage list with a connector line — Reading photos → Sensing mood → Composing → Polishing. Completed steps get a filled check disc, the active step pulses, pending steps are hollow rings. Gives the 1–3 second wait a sense of what the AI is doing without flooding the screen."/>
+      <Bullet title="C · Skeleton preview"
+        body="Most ambitious. Full-bleed hero photo + skeleton shimmer where the title, tags and body will land — the screen looks like the detail page being filled in. A soft accent banner above the home indicator says 'Writing your diary…' with a slightly thicker progress track. Promises the result before it arrives."/>
+      <Bullet title="Cancel & speed"
+        body="Generation takes 1–3 seconds; an explicit Cancel button would invite anxiety on a path that's near-instant. The back button on the AppBar (and the system back gesture) already cover the rare case. All three variants use an indeterminate progress affordance — no fake percentages."/>
+      <Bullet title="My recommendation"
+        body="Ship C (Skeleton preview). It uses the moment to introduce the detail-page layout the user is about to land on, eliminating the route-change flash entirely. B is the safe alternative if the team wants explicit progress copy."/>
+    </div>
+  );
+}
+
+// ─── Generating-screen Flutter code ───────────────────────────
+const GENERATING_FLUTTER_CODE = `// Refactored diary_preview_screen.dart — Hero language during generation.
+// Drops the four CustomCard stack (date / prompt / photos / loading)
+// and renders one continuous editorial surface that mirrors the detail
+// screen the result will land on.
+//
+// Wraps DiaryPreviewController — the existing controller that manages
+// generation state, photo processing and the final navigation. Only the
+// build() output changes.
+
+class DiaryPreviewScreen extends StatefulWidget {
+  final List<AssetEntity> selectedAssets;
+  final WritingPrompt? selectedPrompt;
+  final String? contextText;
+  const DiaryPreviewScreen({
+    super.key,
+    required this.selectedAssets,
+    this.selectedPrompt,
+    this.contextText,
+  });
+  @override
+  State<DiaryPreviewScreen> createState() => _DiaryPreviewScreenState();
+}
+
+class _DiaryPreviewScreenState extends State<DiaryPreviewScreen> {
+  late final DiaryPreviewController _controller;
+  // … initState / dispose / generation flow identical to the original …
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cs = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
+    final accent = isDark ? AppColors.accentLight : AppColors.accentDark;
+
+    return Scaffold(
+      backgroundColor: cs.surface,
+      body: Stack(children: [
+        // ───── hero photo (matches DetailScreen layout) ─────
+        Column(children: [
+          Hero(
+            tag: 'diary-detail-asset-\${widget.selectedAssets.first.id}',
+            child: AspectRatio(
+              aspectRatio: 4 / 3,
+              child: Stack(fit: StackFit.expand, children: [
+                DiaryHeroPhoto(asset: widget.selectedAssets.first),
+                const _TopScrim(),
+                if (widget.selectedAssets.length > 1)
+                  Positioned(
+                    right: 14, bottom: 14,
+                    child: _PhotoCountBadge(
+                      current: 1, total: widget.selectedAssets.length),
+                  ),
+              ]),
+            ),
+          ),
+          Expanded(child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              // date label (same tier as everywhere else)
+              _DateLine(date: _controller.diaryDate),
+              const SizedBox(height: 12),
+
+              // skeleton title (two lines)
+              _SkeletonBar(width: 0.85, height: 22, radius: 6),
+              const SizedBox(height: 10),
+              _SkeletonBar(width: 0.55, height: 22, radius: 6),
+              const SizedBox(height: 16),
+
+              // skeleton chip row
+              Row(children: const [
+                _SkeletonBar(width: null, fixedWidth: 70, height: 22, radius: 6),
+                SizedBox(width: 6),
+                _SkeletonBar(width: null, fixedWidth: 86, height: 22, radius: 6),
+                SizedBox(width: 6),
+                _SkeletonBar(width: null, fixedWidth: 58, height: 22, radius: 6),
+              ]),
+
+              const SizedBox(height: 20),
+              const _Hairline(),
+              const SizedBox(height: 20),
+
+              // skeleton body lines
+              const _SkeletonBar(width: 1.00, height: 12, radius: 4),
+              const SizedBox(height: 10),
+              const _SkeletonBar(width: 0.96, height: 12, radius: 4),
+              const SizedBox(height: 10),
+              const _SkeletonBar(width: 1.00, height: 12, radius: 4),
+              const SizedBox(height: 10),
+              const _SkeletonBar(width: 0.78, height: 12, radius: 4),
+            ]),
+          )),
+
+          // generating banner pinned above the safe area
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Column(children: [
+              _GeneratingBanner(
+                photoCount: widget.selectedAssets.length,
+                promptCategory: widget.selectedPrompt?.category,
+                statusText: _controller.statusText,
+              ),
+              const SizedBox(height: 10),
+              const _IndeterminateBar(),
+            ]),
+          ),
+          SizedBox(height: MediaQuery.of(context).padding.bottom),
+        ]),
+
+        // ───── floating back button over the scrim ─────
+        Positioned(
+          top: MediaQuery.of(context).padding.top + 4,
+          left: 8,
+          child: _FloatingBackButton(onTap: () => Navigator.pop(context)),
+        ),
+      ]),
+    );
+  }
+}
+
+// ─── shimmering skeleton bar ────────────────────────────────────
+class _SkeletonBar extends StatefulWidget {
+  final double? width;       // 0…1 fraction of parent; null → use fixedWidth
+  final double? fixedWidth;  // px (used when width is null)
+  final double height;
+  final double radius;
+  const _SkeletonBar({
+    this.width, this.fixedWidth,
+    required this.height, required this.radius,
+  });
+  @override
+  State<_SkeletonBar> createState() => _SkeletonBarState();
+}
+
+class _SkeletonBarState extends State<_SkeletonBar>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ac = AnimationController(
+    vsync: this, duration: const Duration(milliseconds: 1400),
+  )..repeat();
+
+  @override
+  void dispose() { _ac.dispose(); super.dispose(); }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final base = isDark
+      ? Colors.white.withValues(alpha: 0.05)
+      : Colors.black.withValues(alpha: 0.05);
+    final hi = isDark
+      ? Colors.white.withValues(alpha: 0.10)
+      : Colors.black.withValues(alpha: 0.09);
+
+    final bar = AnimatedBuilder(
+      animation: _ac,
+      builder: (_, __) => Container(
+        height: widget.height,
+        decoration: BoxDecoration(
+          color: base,
+          borderRadius: BorderRadius.circular(widget.radius),
+          gradient: LinearGradient(
+            colors: [base, hi, base],
+            stops: const [0.0, 0.5, 1.0],
+            begin: Alignment(-1 + _ac.value * 3, 0),
+            end:   Alignment( 1 + _ac.value * 3, 0),
+          ),
+        ),
+      ),
+    );
+
+    if (widget.fixedWidth != null) {
+      return SizedBox(width: widget.fixedWidth, child: bar);
+    }
+    return FractionallySizedBox(
+      widthFactor: widget.width ?? 1.0,
+      alignment: Alignment.centerLeft,
+      child: bar,
+    );
+  }
+}
+
+// ─── generating banner (accent-tinted) ───────────────────────────
+class _GeneratingBanner extends StatelessWidget {
+  final int photoCount;
+  final String? promptCategory;
+  final String statusText;
+  const _GeneratingBanner({
+    required this.photoCount,
+    required this.promptCategory,
+    required this.statusText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cs = Theme.of(context).colorScheme;
+    final accent = isDark ? AppColors.accentLight : AppColors.accentDark;
+    final bg = isDark
+      ? AppColors.accentLight.withValues(alpha: 0.14)
+      : AppColors.accent.withValues(alpha: 0.10);
+    final border = isDark
+      ? AppColors.accentLight.withValues(alpha: 0.22)
+      : AppColors.accent.withValues(alpha: 0.20);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: border, width: 0.5),
+      ),
+      child: Row(children: [
+        _PulsingDisc(color: accent),
+        const SizedBox(width: 12),
+        Expanded(child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(statusText, style: TextStyle(
+              fontSize: 13.5, fontWeight: FontWeight.w700,
+              letterSpacing: -0.1, height: 1.25, color: cs.onSurface,
+            ), maxLines: 1, overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 2),
+            Text(
+              promptCategory == null
+                ? l10n.diaryGenerationCaptionNoPrompt(photoCount)
+                : l10n.diaryGenerationCaptionWithPrompt(
+                    photoCount, promptCategory!.toLowerCase()),
+              style: TextStyle(
+                fontSize: 11.5, letterSpacing: 0.2,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          ],
+        )),
+      ]),
+    );
+  }
+}
+
+class _PulsingDisc extends StatefulWidget {
+  final Color color;
+  const _PulsingDisc({required this.color});
+  @override
+  State<_PulsingDisc> createState() => _PulsingDiscState();
+}
+
+class _PulsingDiscState extends State<_PulsingDisc>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ac = AnimationController(
+    vsync: this, duration: const Duration(milliseconds: 1600),
+  )..repeat(reverse: true);
+  @override
+  void dispose() { _ac.dispose(); super.dispose(); }
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: Tween(begin: 0.6, end: 1.0).animate(_ac),
+      child: Container(
+        width: 28, height: 28,
+        decoration: BoxDecoration(color: widget.color, shape: BoxShape.circle),
+        child: const Icon(
+          Icons.auto_awesome_rounded,
+          size: 14, color: Colors.white,
+        ),
+      ),
+    );
+  }
+}
+
+// ─── indeterminate accent bar ───────────────────────────────────
+class _IndeterminateBar extends StatelessWidget {
+  const _IndeterminateBar();
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final accent = isDark ? AppColors.accentLight : AppColors.accentDark;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: LinearProgressIndicator(
+        minHeight: 4,
+        backgroundColor: isDark
+          ? Colors.white.withValues(alpha: 0.06)
+          : Colors.black.withValues(alpha: 0.06),
+        valueColor: AlwaysStoppedAnimation<Color>(accent),
+      ),
+    );
+  }
+}
+
+// ─── top scrim under the floating back button (shared with detail) ──
+class _TopScrim extends StatelessWidget {
+  const _TopScrim();
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        alignment: Alignment.topCenter, height: 140,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter, end: Alignment.bottomCenter,
+            colors: [Color(0x73141210), Color(0x00141210)],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FloatingBackButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const _FloatingBackButton({required this.onTap});
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black.withValues(alpha: 0.42),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36, height: 36,
+          child: Icon(Icons.chevron_left_rounded,
+            color: Colors.white, size: 22),
+        ),
+      ),
+    );
+  }
+}`;
+
+function GeneratingCodeCard() {
+  return (
+    <div style={{
+      width: '100%', height: '100%',
+      background: '#1F1B17', color: '#E8E2DC', borderRadius: 18,
+      padding: 24, boxSizing: 'border-box',
+      display: 'flex', flexDirection: 'column', gap: 16,
+      fontFamily: '"Noto Sans JP", -apple-system, system-ui, sans-serif',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <div style={{ fontSize: 22, fontWeight: 700, color: '#FAF8F5', letterSpacing: -0.3 }}>
+          Flutter handoff · generation
+        </div>
+        <div style={{ fontSize: 13, color: '#9E9891' }}>
+          diary_preview_screen.dart · skeleton variant
+        </div>
+      </div>
+      <div style={{ fontSize: 13, lineHeight: 1.55, color: '#C7C0B8' }}>
+        Refactor of <code style={{ background: '#2E2A27', padding: '1px 6px', borderRadius: 4, color: '#E4BEA3' }}>DiaryPreviewScreen</code>.
+        Drops the four <code style={{ background: '#2E2A27', padding: '1px 6px', borderRadius: 4, color: '#E4BEA3' }}>CustomCard</code> stack
+        (date / prompt / photos / loading) and renders one editorial surface that mirrors the detail screen — same Hero photo,
+        same <code style={{ background: '#2E2A27', padding: '1px 6px', borderRadius: 4, color: '#E4BEA3' }}>_TopScrim</code>,
+        same <code style={{ background: '#2E2A27', padding: '1px 6px', borderRadius: 4, color: '#E4BEA3' }}>Hero</code> tag
+        so the cross-fade into the final entry is seamless.
+        <code style={{ background: '#2E2A27', padding: '1px 6px', borderRadius: 4, color: '#E4BEA3', marginLeft: 4 }}>DiaryPreviewController</code> (generation state, photo processing, success navigation) stays untouched.
+      </div>
+      <pre style={{
+        flex: 1, margin: 0, overflow: 'auto',
+        background: '#15120F', borderRadius: 12, padding: 18,
+        fontFamily: '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace',
+        fontSize: 11.5, lineHeight: 1.55, color: '#E8E2DC',
+      }}>{GENERATING_FLUTTER_CODE}</pre>
+    </div>
+  );
+}
+
 // ─── canvas ──────────────────────────────────────────────────────
 const PHONE_W = 460, PHONE_H = 950;
 
@@ -3561,6 +3976,43 @@ function App() {
         subtitle="filter_bottom_sheet.dart + ActiveFiltersDisplay rewrite. DiaryFilter model untouched.">
         <DCArtboard id="filter-flutter" label="filter_bottom_sheet.dart" width={920} height={PHONE_H}>
           <FilterCodeCard/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="generating-notes" title="Diary generation — Hero applied"
+        subtitle="The 1–3 seconds between prompt and entry. Three takes on the same content (photos + prompt + status), all on one editorial surface — no per-section CustomCard chrome.">
+        <DCArtboard id="generating-notes-card" label="What changed" width={520} height={PHONE_H}>
+          <GeneratingNotesCard/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="generating-light" title="Generation · Light"
+        subtitle="A · Calm editorial — B · Staged list — C · Skeleton preview (recommended).">
+        {GEN_VARIANTS.map((v) => (
+          <DCArtboard key={v.id} id={`generating-${v.id}-light`} label={v.label}
+            width={PHONE_W} height={PHONE_H}>
+            <IOSDevice width={402} height={874} dark={false}>
+              <v.Screen tokens={lightTokens}/>
+            </IOSDevice>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      <DCSection id="generating-dark" title="Generation · Dark">
+        {GEN_VARIANTS.map((v) => (
+          <DCArtboard key={v.id} id={`generating-${v.id}-dark`} label={v.label}
+            width={PHONE_W} height={PHONE_H}>
+            <IOSDevice width={402} height={874} dark={true}>
+              <v.Screen tokens={darkTokens}/>
+            </IOSDevice>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      <DCSection id="generating-handoff" title="Flutter handoff · generation"
+        subtitle="Refactored diary_preview_screen.dart. Shared _TopScrim, _PhotoCountBadge and Hero tag with the detail screen so the cross-fade into the final entry is seamless.">
+        <DCArtboard id="generating-flutter" label="diary_preview_screen.dart" width={920} height={PHONE_H}>
+          <GeneratingCodeCard/>
         </DCArtboard>
       </DCSection>
     </DesignCanvas>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1027,6 +1027,21 @@
   "@diaryPreviewDiscardDialogConfirm": {
     "description": "Confirmation button label for discarding the diary"
   },
+  "diaryGenerationCaptionNoPrompt": "{photoCount} {photoCount, plural, =1{photo} other{photos}}",
+  "@diaryGenerationCaptionNoPrompt": {
+    "description": "Generating banner caption when no prompt is selected",
+    "placeholders": {
+      "photoCount": { "type": "int", "format": "decimalPattern" }
+    }
+  },
+  "diaryGenerationCaptionWithPrompt": "{photoCount} {photoCount, plural, =1{photo} other{photos}} · {category} prompt",
+  "@diaryGenerationCaptionWithPrompt": {
+    "description": "Generating banner caption with prompt category name",
+    "placeholders": {
+      "photoCount": { "type": "int", "format": "decimalPattern" },
+      "category": { "type": "String" }
+    }
+  },
   "diaryCardUntitled": "Untitled",
   "@diaryCardUntitled": {
     "description": "Fallback title when a diary entry has no title"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1027,6 +1027,21 @@
   "@diaryPreviewDiscardDialogConfirm": {
     "description": "日記破棄を確定するボタンラベル"
   },
+  "diaryGenerationCaptionNoPrompt": "{photoCount}枚の写真",
+  "@diaryGenerationCaptionNoPrompt": {
+    "description": "日記生成中バナーのキャプション（プロンプトなし）",
+    "placeholders": {
+      "photoCount": { "type": "int", "format": "decimalPattern" }
+    }
+  },
+  "diaryGenerationCaptionWithPrompt": "{photoCount}枚の写真 · {category}プロンプト",
+  "@diaryGenerationCaptionWithPrompt": {
+    "description": "日記生成中バナーのキャプション（プロンプトあり）",
+    "placeholders": {
+      "photoCount": { "type": "int", "format": "decimalPattern" },
+      "category": { "type": "String" }
+    }
+  },
   "diaryCardUntitled": "無題",
   "@diaryCardUntitled": {
     "description": "タイトル未設定時のフォールバック"

--- a/lib/screens/diary_preview/diary_preview_generating.dart
+++ b/lib/screens/diary_preview/diary_preview_generating.dart
@@ -398,19 +398,23 @@ class _FloatingBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.black.withValues(alpha: 0.42),
-      shape: const CircleBorder(),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: const SizedBox(
-          width: 36,
-          height: 36,
-          child: Icon(
-            Icons.chevron_left_rounded,
-            color: Colors.white,
-            size: 22,
+    return Semantics(
+      button: true,
+      label: context.l10n.commonBack,
+      child: Material(
+        color: Colors.black.withValues(alpha: 0.42),
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: const SizedBox(
+            width: 36,
+            height: 36,
+            child: Icon(
+              Icons.chevron_left_rounded,
+              color: Colors.white,
+              size: 22,
+            ),
           ),
         ),
       ),

--- a/lib/screens/diary_preview/diary_preview_generating.dart
+++ b/lib/screens/diary_preview/diary_preview_generating.dart
@@ -1,0 +1,485 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import '../../core/result/result.dart';
+import '../../core/service_locator.dart';
+import '../../localization/localization_extensions.dart';
+import '../../models/writing_prompt.dart';
+import '../../services/interfaces/photo_cache_service_interface.dart';
+import '../../ui/components/loading_shimmer.dart';
+import '../../ui/design_system/app_colors.dart';
+import '../../ui/design_system/app_typography.dart';
+import '../../utils/prompt_category_utils.dart';
+
+/// AI生成中に表示するスケルトンプレビュー画面（Variant C: Skeleton preview）。
+///
+/// 詳細画面と同じレイアウト（ヒーロー写真 + コンテンツエリア）を
+/// シマープレースホルダーで先取り表示し、生成完了後のクロスフェードを
+/// 自然にする。
+class DiaryPreviewGeneratingScreen extends StatelessWidget {
+  const DiaryPreviewGeneratingScreen({
+    super.key,
+    required this.selectedAssets,
+    required this.photoDateTime,
+    required this.selectedPrompt,
+    required this.statusText,
+    required this.onBack,
+  });
+
+  final List<AssetEntity> selectedAssets;
+  final DateTime photoDateTime;
+  final WritingPrompt? selectedPrompt;
+  final String statusText;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = MediaQuery.of(context).padding;
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      body: Stack(
+        children: [
+          Column(
+            children: [
+              // Hero photo (4:3) — extends to y=0, overlaps status bar
+              if (selectedAssets.isNotEmpty)
+                AspectRatio(
+                  aspectRatio: 4 / 3,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      _HeroPhoto(asset: selectedAssets.first),
+                      const _TopScrim(),
+                      if (selectedAssets.length > 1)
+                        Positioned(
+                          right: 14,
+                          bottom: 14,
+                          child: _PhotoCountBadge(
+                            current: 1,
+                            total: selectedAssets.length,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+
+              // Skeleton content (mirrors detail screen layout)
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _DateLine(date: photoDateTime),
+                      const SizedBox(height: 12),
+                      const _SkeletonBar(
+                        widthFactor: 0.85,
+                        height: 22,
+                        radius: 6,
+                      ),
+                      const SizedBox(height: 10),
+                      const _SkeletonBar(
+                        widthFactor: 0.55,
+                        height: 22,
+                        radius: 6,
+                      ),
+                      const SizedBox(height: 16),
+                      const Row(
+                        children: [
+                          _SkeletonBar(fixedWidth: 70, height: 22, radius: 6),
+                          SizedBox(width: 6),
+                          _SkeletonBar(fixedWidth: 86, height: 22, radius: 6),
+                          SizedBox(width: 6),
+                          _SkeletonBar(fixedWidth: 58, height: 22, radius: 6),
+                        ],
+                      ),
+                      const SizedBox(height: 20),
+                      const _Hairline(),
+                      const SizedBox(height: 20),
+                      const _SkeletonBar(height: 12, radius: 4),
+                      const SizedBox(height: 10),
+                      const _SkeletonBar(
+                        widthFactor: 0.96,
+                        height: 12,
+                        radius: 4,
+                      ),
+                      const SizedBox(height: 10),
+                      const _SkeletonBar(height: 12, radius: 4),
+                      const SizedBox(height: 10),
+                      const _SkeletonBar(
+                        widthFactor: 0.78,
+                        height: 12,
+                        radius: 4,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Generating banner pinned above home indicator
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Column(
+                  children: [
+                    _GeneratingBanner(
+                      photoCount: selectedAssets.length,
+                      selectedPrompt: selectedPrompt,
+                      statusText: statusText,
+                    ),
+                    const SizedBox(height: 10),
+                    const _IndeterminateBar(),
+                  ],
+                ),
+              ),
+              SizedBox(height: padding.bottom),
+            ],
+          ),
+
+          // Floating back button over the scrim
+          Positioned(
+            top: padding.top + 4,
+            left: 8,
+            child: _FloatingBackButton(onTap: onBack),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroPhoto extends StatefulWidget {
+  const _HeroPhoto({required this.asset});
+
+  final AssetEntity asset;
+
+  @override
+  State<_HeroPhoto> createState() => _HeroPhotoState();
+}
+
+class _HeroPhotoState extends State<_HeroPhoto> {
+  late Future<Result<Uint8List>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = serviceLocator.get<IPhotoCacheService>().getThumbnail(
+      widget.asset,
+      width: 800,
+      height: 600,
+      quality: 85,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return FutureBuilder<Result<Uint8List>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.data is Success<Uint8List>) {
+          return Image.memory(
+            (snapshot.data! as Success<Uint8List>).value,
+            fit: BoxFit.cover,
+            gaplessPlayback: true,
+          );
+        }
+        return Container(color: cs.surfaceContainerHighest);
+      },
+    );
+  }
+}
+
+class _SkeletonBar extends StatelessWidget {
+  const _SkeletonBar({
+    this.widthFactor,
+    this.fixedWidth,
+    required this.height,
+    required this.radius,
+  });
+
+  final double? widthFactor;
+  final double? fixedWidth;
+  final double height;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final bar = LoadingShimmer(
+      child: Container(
+        height: height,
+        width: fixedWidth,
+        decoration: BoxDecoration(
+          color: AppColors.surfaceVariant,
+          borderRadius: BorderRadius.circular(radius),
+        ),
+      ),
+    );
+
+    if (fixedWidth != null) return bar;
+    return FractionallySizedBox(
+      widthFactor: widthFactor ?? 1.0,
+      alignment: Alignment.centerLeft,
+      child: bar,
+    );
+  }
+}
+
+class _GeneratingBanner extends StatelessWidget {
+  const _GeneratingBanner({
+    required this.photoCount,
+    required this.selectedPrompt,
+    required this.statusText,
+  });
+
+  final int photoCount;
+  final WritingPrompt? selectedPrompt;
+  final String statusText;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cs = Theme.of(context).colorScheme;
+    final accent = isDark ? AppColors.accentLight : AppColors.accentDark;
+    final bg = isDark
+        ? AppColors.accentLight.withValues(alpha: 0.14)
+        : AppColors.accent.withValues(alpha: 0.10);
+    final border = isDark
+        ? AppColors.accentLight.withValues(alpha: 0.22)
+        : AppColors.accent.withValues(alpha: 0.20);
+
+    final l10n = context.l10n;
+    final caption = selectedPrompt == null
+        ? l10n.diaryGenerationCaptionNoPrompt(photoCount)
+        : l10n.diaryGenerationCaptionWithPrompt(
+            photoCount,
+            PromptCategoryUtils.getCategoryDisplayName(
+              selectedPrompt!.category,
+              locale: Localizations.localeOf(context),
+            ).toLowerCase(),
+          );
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: border, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          _PulsingDisc(color: accent),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  statusText,
+                  style: TextStyle(
+                    fontSize: 13.5,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.1,
+                    height: 1.25,
+                    color: cs.onSurface,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  caption,
+                  style: TextStyle(
+                    fontSize: 11.5,
+                    letterSpacing: 0.2,
+                    color: cs.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PulsingDisc extends StatefulWidget {
+  const _PulsingDisc({required this.color});
+
+  final Color color;
+
+  @override
+  State<_PulsingDisc> createState() => _PulsingDiscState();
+}
+
+class _PulsingDiscState extends State<_PulsingDisc>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ac = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1600),
+  )..repeat(reverse: true);
+  late final Animation<double> _opacity = Tween<double>(
+    begin: 0.6,
+    end: 1.0,
+  ).animate(_ac);
+
+  @override
+  void dispose() {
+    _ac.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _opacity,
+      child: Container(
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(color: widget.color, shape: BoxShape.circle),
+        child: const Icon(
+          Icons.auto_awesome_rounded,
+          size: 14,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}
+
+class _IndeterminateBar extends StatelessWidget {
+  const _IndeterminateBar();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final accent = isDark ? AppColors.accentLight : AppColors.accentDark;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: LinearProgressIndicator(
+        minHeight: 4,
+        backgroundColor: isDark
+            ? Colors.white.withValues(alpha: 0.06)
+            : Colors.black.withValues(alpha: 0.06),
+        valueColor: AlwaysStoppedAnimation<Color>(accent),
+      ),
+    );
+  }
+}
+
+class _TopScrim extends StatelessWidget {
+  const _TopScrim();
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        alignment: Alignment.topCenter,
+        height: 140,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color(0x73141210), Color(0x00141210)],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FloatingBackButton extends StatelessWidget {
+  const _FloatingBackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black.withValues(alpha: 0.42),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(
+            Icons.chevron_left_rounded,
+            color: Colors.white,
+            size: 22,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PhotoCountBadge extends StatelessWidget {
+  const _PhotoCountBadge({required this.current, required this.total});
+
+  final int current;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.photo_library_rounded,
+            size: 11,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 5),
+          Text(
+            context.l10n.photoCountIndicator(current, total),
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DateLine extends StatelessWidget {
+  const _DateLine({required this.date});
+
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      context.l10n.formatMonthDayWithDayName(date),
+      style: AppTypography.withColor(
+        AppTypography.dateLabel,
+        AppColors.accentMuted,
+      ),
+    );
+  }
+}
+
+class _Hairline extends StatelessWidget {
+  const _Hairline();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 0.5,
+      color: Theme.of(context).colorScheme.outlineVariant,
+    );
+  }
+}

--- a/lib/screens/diary_preview/diary_preview_screen.dart
+++ b/lib/screens/diary_preview/diary_preview_screen.dart
@@ -17,6 +17,7 @@ import '../../ui/animations/micro_interactions.dart';
 import '../diary_detail_screen.dart';
 import 'diary_preview_body.dart';
 import 'diary_preview_dialogs.dart';
+import 'diary_preview_generating.dart';
 
 /// 生成された日記のプレビュー画面
 class DiaryPreviewScreen extends StatefulWidget {
@@ -172,6 +173,20 @@ class _DiaryPreviewScreenState extends State<DiaryPreviewScreen> {
     return ListenableBuilder(
       listenable: _controller,
       builder: (context, child) {
+        // 生成中（初期化・AI処理）はスケルトンプレビュー画面を表示
+        if (_controller.isInitializing || _controller.isLoading) {
+          return PopScope(
+            canPop: true,
+            child: DiaryPreviewGeneratingScreen(
+              selectedAssets: widget.selectedAssets,
+              photoDateTime: _controller.photoDateTime,
+              selectedPrompt: _controller.selectedPrompt,
+              statusText: _generatingStatusText(context),
+              onBack: () => Navigator.of(context).pop(),
+            ),
+          );
+        }
+
         return PopScope(
           canPop: false,
           onPopInvokedWithResult: (didPop, result) async {
@@ -215,6 +230,13 @@ class _DiaryPreviewScreenState extends State<DiaryPreviewScreen> {
         );
       },
     );
+  }
+
+  String _generatingStatusText(BuildContext context) {
+    if (_controller.isAnalyzingPhotos) {
+      return context.l10n.diaryPreviewAnalyzingPhotos;
+    }
+    return context.l10n.diaryPreviewGeneratingDiaryTitle;
   }
 
   String _getErrorMessage() {

--- a/test/widget/diary_preview_screen_test.dart
+++ b/test/widget/diary_preview_screen_test.dart
@@ -1,15 +1,20 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/core/service_locator.dart';
+import 'package:smart_photo_diary/screens/diary_preview/diary_preview_generating.dart';
 import 'package:smart_photo_diary/screens/diary_preview/diary_preview_screen.dart';
 import 'package:smart_photo_diary/screens/diary_preview/diary_preview_body.dart';
 import 'package:smart_photo_diary/models/diary_length.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/photo_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/photo_cache_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/ai_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/diary_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/diary_crud_service_interface.dart';
@@ -19,6 +24,8 @@ import 'package:smart_photo_diary/services/interfaces/subscription_service_inter
 import '../integration/mocks/mock_services.dart';
 import '../test_helpers/mock_platform_channels.dart';
 import '../test_helpers/widget_test_helpers.dart';
+
+class MockIPhotoCacheService extends Mock implements IPhotoCacheService {}
 
 void main() {
   late MockILoggingService mockLogger;
@@ -41,6 +48,20 @@ void main() {
     // Synchronous services required by DiaryPreviewController constructor
     serviceLocator.registerSingleton<ILoggingService>(mockLogger);
     serviceLocator.registerSingleton<IPhotoService>(mockPhoto);
+
+    // IPhotoCacheService is used by DiaryPreviewGeneratingScreen._HeroPhoto
+    final mockPhotoCache = MockIPhotoCacheService();
+    when(
+      () => mockPhotoCache.getThumbnail(
+        any(),
+        width: any(named: 'width'),
+        height: any(named: 'height'),
+        quality: any(named: 'quality'),
+      ),
+    ).thenAnswer(
+      (_) async => const Failure<Uint8List>(PhotoAccessException('test')),
+    );
+    serviceLocator.registerSingleton<IPhotoCacheService>(mockPhotoCache);
 
     // ISettingsService is resolved asynchronously in DiaryPreviewScreen
     final mockSettings = MockSettingsService();
@@ -109,90 +130,72 @@ void main() {
     );
   }
 
-  /// Pump a few frames to trigger initState / postFrameCallback without
-  /// waiting for pumpAndSettle (which would time out due to ongoing animations
-  /// and never-completing async services).
-  Future<void> pumpFrames(WidgetTester tester) async {
-    await tester.pump(); // first frame
+  /// Build the screen at phone size and pump a few frames.
+  ///
+  /// Sets a 390×844 surface BEFORE pumpWidget so the 4:3 hero photo doesn't
+  /// overflow the default 800×600 test canvas. Resets the size on teardown.
+  Future<void> buildAndPump(WidgetTester tester, Widget widget) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(widget);
     await tester.pump(const Duration(milliseconds: 200)); // async init
     await tester.pump(const Duration(milliseconds: 200)); // animations
   }
 
   group('DiaryPreviewScreen', () {
     group('AppBar display', () {
-      testWidgets('shows AppBar with preview title', (
+      testWidgets('no AppBar shown during loading (skeleton screen)', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
-        expect(find.byType(AppBar), findsOneWidget);
-        expect(find.text('Diary preview'), findsOneWidget);
-      });
-
-      testWidgets('AppBar uses theme default background color', (
-        WidgetTester tester,
-      ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
-
-        // AppBar now uses theme default (no explicit backgroundColor)
-        final appBar = tester.widget<AppBar>(find.byType(AppBar));
-        expect(appBar.backgroundColor, isNull);
+        // During generation the skeleton screen is shown — no AppBar.
+        expect(find.byType(AppBar), findsNothing);
       });
     });
 
     group('Initial loading state', () {
-      testWidgets('shows CircularProgressIndicator during initialization', (
+      testWidgets('shows DiaryPreviewGeneratingScreen during loading', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        // Pump enough to fire the postFrameCallback and its internal
-        // Future.delayed(100ms), but async services never complete so
-        // the controller stays in loading state.
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
-        // PhotoGallery's PhotoThumbnailWidget also shows a loading indicator,
-        // so multiple CircularProgressIndicators may exist simultaneously.
-        expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+        expect(find.byType(DiaryPreviewGeneratingScreen), findsOneWidget);
+        expect(find.byType(DiaryPreviewBody), findsNothing);
       });
 
-      testWidgets('shows generating text after initialization phase', (
+      testWidgets('shows generating status text during loading phase', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
-        // After the 100ms delay, isInitializing becomes false and isLoading
-        // becomes true. The loading states widget shows "Creating your diary..."
+        // The banner inside DiaryPreviewGeneratingScreen shows the status text.
         expect(find.text('Creating your diary...'), findsOneWidget);
       });
     });
 
     group('DiaryPreviewBody', () {
-      testWidgets('DiaryPreviewBody widget is rendered', (
+      testWidgets('DiaryPreviewBody is not shown during loading', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
-        expect(find.byType(DiaryPreviewBody), findsOneWidget);
+        // Body is only shown after generation completes.
+        expect(find.byType(DiaryPreviewBody), findsNothing);
       });
     });
 
     group('PopScope configuration', () {
-      testWidgets('PopScope widget exists with canPop false', (
+      testWidgets('PopScope exists with canPop true during loading', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
-        // Find PopScope via predicate since multiple PopScopes may exist
-        // in the widget tree (from MaterialApp scaffolding, routes, etc.).
+        // During generation, back navigation is allowed freely (canPop: true).
         final popScopeFinder = find.byWidgetPredicate(
-          (widget) => widget is PopScope && widget.canPop == false,
+          (widget) => widget is PopScope && widget.canPop == true,
         );
-        expect(popScopeFinder, findsOneWidget);
+        expect(popScopeFinder, findsAtLeastNWidgets(1));
       });
     });
 
@@ -200,8 +203,7 @@ void main() {
       testWidgets('save icon is not shown in AppBar during loading', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
         // save_rounded icon should not appear while initializing/loading
         expect(find.byIcon(Icons.save_rounded), findsNothing);
@@ -210,8 +212,7 @@ void main() {
       testWidgets('bottom bar is not shown during loading', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
         // The bottom bar with the "Save diary" button should not appear
         // while the controller is still loading or initializing.
@@ -223,8 +224,7 @@ void main() {
       testWidgets('renders Scaffold as the main widget', (
         WidgetTester tester,
       ) async {
-        await tester.pumpWidget(buildScreen());
-        await pumpFrames(tester);
+        await buildAndPump(tester, buildScreen());
 
         expect(find.byType(Scaffold), findsOneWidget);
       });


### PR DESCRIPTION
## Summary
- Replace the old 4-card loading UI (date/prompt/photos/status cards) with a full-screen skeleton preview (`DiaryPreviewGeneratingScreen`) that mirrors the detail screen layout
- Add shimmer placeholder bars using the existing `LoadingShimmer` component, a hero photo, generating banner with pulsing disc, and indeterminate progress bar
- Add `diaryGenerationCaptionNoPrompt` / `diaryGenerationCaptionWithPrompt` l10n strings (EN + JA) for the banner caption
- Update `DiaryPreviewScreen.build` to switch to the skeleton screen while `isInitializing || isLoading`
- Simplify code: `_SkeletonBar` converted from StatefulWidget to StatelessWidget delegating to `LoadingShimmer`; `_PulsingDisc` Tween moved out of `build()`; unused `_cache` field removed; `_PhotoCountBadge` uses existing `photoCountIndicator` l10n key

## Test Plan
- Widget tests in `test/widget/diary_preview_screen_test.dart` updated and passing (8/8)
- `fvm flutter analyze` shows no issues
- Codex review: no critical issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 日記生成中の専用UI画面を追加。3つのデザインバリアント（編集版・段階版・スケルトン版）で表示可能に
  * 生成中のステータス表示機能を実装
  * 英語・日本語対応の翻訳文言を追加

* **テスト**
  * 生成中の画面挙動確認テストを更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->