### PR TITLE
refactor: enforce Result<T> consistency across service layer

### DIFF
--- a/lib/services/mixins/purchase_event_handler.dart
+++ b/lib/services/mixins/purchase_event_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:in_app_purchase/in_app_purchase.dart' as iap;
+import '../../core/errors/app_exceptions.dart';
 import '../../models/subscription_status.dart';
 import '../../models/plans/plan.dart';
 import '../../constants/subscription_constants.dart';
@@ -170,7 +171,9 @@ mixin PurchaseEventHandler on ServiceLogging {
   ) async {
     final plan = PlanFactory.getPlanByProductId(purchaseDetails.productID);
     if (plan == null) {
-      throw ArgumentError('Unknown product ID: ${purchaseDetails.productID}');
+      throw ServiceException(
+        'Unknown product ID: ${purchaseDetails.productID}',
+      );
     }
     await updateSubscriptionFromPurchase(purchaseDetails, plan);
     return plan;
@@ -301,7 +304,7 @@ mixin PurchaseEventHandler on ServiceLogging {
           days: SubscriptionConstants.subscriptionYearDays,
         );
       } else {
-        throw ArgumentError('Basic plan cannot be purchased');
+        throw const ServiceException('Basic plan cannot be purchased');
       }
 
       // 現在の使用量を引き継ぐ（月途中のアップグレードで使用量がリセットされるのを防止）

--- a/lib/services/prompt_service.dart
+++ b/lib/services/prompt_service.dart
@@ -262,9 +262,10 @@ class PromptService implements IPromptService {
   }
 
   void _ensureInitialized() {
-    assert(
-      _isInitialized,
-      'PromptService is not initialized. Call initialize() first.',
-    );
+    if (!_isInitialized) {
+      throw StateError(
+        'PromptService is not initialized. Call initialize() first.',
+      );
+    }
   }
 }

--- a/lib/services/prompt_service.dart
+++ b/lib/services/prompt_service.dart
@@ -262,10 +262,9 @@ class PromptService implements IPromptService {
   }
 
   void _ensureInitialized() {
-    if (!_isInitialized) {
-      throw StateError(
-        'PromptService is not initialized. Call initialize() first.',
-      );
-    }
+    assert(
+      _isInitialized,
+      'PromptService is not initialized. Call initialize() first.',
+    );
   }
 }

--- a/lib/services/purchase_flow_delegate.dart
+++ b/lib/services/purchase_flow_delegate.dart
@@ -58,10 +58,14 @@ class PurchaseFlowDelegate with PurchaseErrorHandlerMixin {
       );
       _setIsPurchasing(true);
 
-      final productDetails = await _productDelegate.queryProductDetails(
+      final detailsResult = await _productDelegate.queryProductDetails(
         productId,
       );
-      final purchaseParam = PurchaseParam(productDetails: productDetails);
+      if (detailsResult.isFailure) {
+        _setIsPurchasing(false);
+        return Failure(detailsResult.error);
+      }
+      final purchaseParam = PurchaseParam(productDetails: detailsResult.value);
 
       try {
         _log('Calling buyNonConsumable...');

--- a/lib/services/purchase_product_delegate.dart
+++ b/lib/services/purchase_product_delegate.dart
@@ -160,33 +160,43 @@ class PurchaseProductDelegate with PurchaseErrorHandlerMixin {
   }
 
   /// App Store から商品詳細を取得する
-  Future<ProductDetails> queryProductDetails(String productId) async {
-    _loggingService?.debug(
-      'Querying product details',
-      context: logTag,
-      data: {'productId': productId},
-    );
-    final response = await _getInAppPurchase()!.queryProductDetails({
-      productId,
-    });
-
-    if (response.error != null) {
-      throw ServiceException(
-        'Failed to get product details for purchase',
-        details: response.error.toString(),
+  Future<Result<ProductDetails>> queryProductDetails(String productId) async {
+    try {
+      _loggingService?.debug(
+        'Querying product details',
+        context: logTag,
+        data: {'productId': productId},
       );
-    }
+      final response = await _getInAppPurchase()!.queryProductDetails({
+        productId,
+      });
 
-    if (response.productDetails.isEmpty) {
-      throw ServiceException('Product not found: $productId');
-    }
+      if (response.error != null) {
+        return Failure(
+          ServiceException(
+            'Failed to get product details for purchase',
+            details: response.error.toString(),
+          ),
+        );
+      }
 
-    final details = response.productDetails.first;
-    _log(
-      'Product details retrieved',
-      data: {'id': details.id, 'title': details.title, 'price': details.price},
-    );
-    return details;
+      if (response.productDetails.isEmpty) {
+        return Failure(ServiceException('Product not found: $productId'));
+      }
+
+      final details = response.productDetails.first;
+      _log(
+        'Product details retrieved',
+        data: {
+          'id': details.id,
+          'title': details.title,
+          'price': details.price,
+        },
+      );
+      return Success(details);
+    } catch (e) {
+      return handlePurchaseError(e, 'queryProductDetails', details: productId);
+    }
   }
 
   // =================================================================

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -71,23 +71,18 @@ class SettingsService implements ISettingsService {
   }
 
   @override
-  Future<Result<void>> setPhotoTypeFilter(PhotoTypeFilter filter) async {
-    if (_preferences == null) {
-      return const Failure(
-        SettingsException('SettingsService is not initialized'),
+  Future<Result<void>> setPhotoTypeFilter(PhotoTypeFilter filter) =>
+      _withPreferences(
+        (prefs) => ResultHelper.tryExecuteAsync(() async {
+          final saved = await prefs.setInt(_photoTypeFilterKey, filter.index);
+          if (!saved) {
+            throw const SettingsException(
+              'Failed to persist photo type filter',
+            );
+          }
+          _photoTypeFilterNotifier.value = filter;
+        }, context: 'SettingsService.setPhotoTypeFilter'),
       );
-    }
-    return ResultHelper.tryExecuteAsync(() async {
-      final saved = await _preferences!.setInt(
-        _photoTypeFilterKey,
-        filter.index,
-      );
-      if (!saved) {
-        throw const SettingsException('Failed to persist photo type filter');
-      }
-      _photoTypeFilterNotifier.value = filter;
-    }, context: 'SettingsService.setPhotoTypeFilter');
-  }
 
   // 日記の長さ
   @override
@@ -109,17 +104,12 @@ class SettingsService implements ISettingsService {
   }
 
   @override
-  Future<Result<void>> setDiaryLength(DiaryLength length) async {
-    if (_preferences == null) {
-      return const Failure(
-        SettingsException('SettingsService is not initialized'),
-      );
-    }
-    return ResultHelper.tryExecuteAsync(
-      () async => _preferences!.setInt(_diaryLengthKey, length.index),
+  Future<Result<void>> setDiaryLength(DiaryLength length) => _withPreferences(
+    (prefs) => ResultHelper.tryExecuteAsync(
+      () async => prefs.setInt(_diaryLengthKey, length.index),
       context: 'SettingsService.setDiaryLength',
-    );
-  }
+    ),
+  );
 
   // テーマモード
   @override
@@ -140,17 +130,12 @@ class SettingsService implements ISettingsService {
   }
 
   @override
-  Future<Result<void>> setThemeMode(ThemeMode themeMode) async {
-    if (_preferences == null) {
-      return const Failure(
-        SettingsException('SettingsService is not initialized'),
-      );
-    }
-    return ResultHelper.tryExecuteAsync(
-      () async => _preferences!.setInt(_themeKey, themeMode.index),
+  Future<Result<void>> setThemeMode(ThemeMode themeMode) => _withPreferences(
+    (prefs) => ResultHelper.tryExecuteAsync(
+      () async => prefs.setInt(_themeKey, themeMode.index),
       context: 'SettingsService.setThemeMode',
-    );
-  }
+    ),
+  );
 
   @override
   Locale? get locale {
@@ -161,21 +146,16 @@ class SettingsService implements ISettingsService {
   }
 
   @override
-  Future<Result<void>> setLocale(Locale? locale) async {
-    if (_preferences == null) {
-      return const Failure(
-        SettingsException('SettingsService is not initialized'),
-      );
-    }
-    return ResultHelper.tryExecuteAsync(() async {
+  Future<Result<void>> setLocale(Locale? locale) => _withPreferences(
+    (prefs) => ResultHelper.tryExecuteAsync(() async {
       if (locale == null) {
-        await _preferences!.remove(_localeKey);
+        await prefs.remove(_localeKey);
       } else {
-        await _preferences!.setString(_localeKey, _serializeLocale(locale));
+        await prefs.setString(_localeKey, _serializeLocale(locale));
       }
       _localeNotifier.value = locale;
-    }, context: 'SettingsService.setLocale');
-  }
+    }, context: 'SettingsService.setLocale'),
+  );
 
   // 初回起動判定
   @override
@@ -192,17 +172,12 @@ class SettingsService implements ISettingsService {
 
   // 初回起動完了を記録
   @override
-  Future<Result<void>> setFirstLaunchCompleted() async {
-    if (_preferences == null) {
-      return const Failure(
-        SettingsException('SettingsService is not initialized'),
-      );
-    }
-    return ResultHelper.tryExecuteAsync(
-      () async => _preferences!.setBool(_firstLaunchKey, false),
+  Future<Result<void>> setFirstLaunchCompleted() => _withPreferences(
+    (prefs) => ResultHelper.tryExecuteAsync(
+      () async => prefs.setBool(_firstLaunchKey, false),
       context: 'SettingsService.setFirstLaunchCompleted',
-    );
-  }
+    ),
+  );
 
   Locale? _loadStoredLocale() => locale;
 
@@ -271,6 +246,19 @@ class SettingsService implements ISettingsService {
   @override
   Future<Result<List<Plan>>> getAvailablePlansV2() =>
       _delegateOr((d) => d.getAvailablePlansV2());
+
+  /// 未初期化時は Failure を返す。_preferences の null チェックをここに集約。
+  Future<Result<void>> _withPreferences(
+    Future<Result<void>> Function(SharedPreferences) fn,
+  ) async {
+    final prefs = _preferences;
+    if (prefs == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
+    return fn(prefs);
+  }
 
   /// delegate 未初期化時は Failure を返す。null チェックをここに集約。
   Future<Result<T>> _delegateOr<T>(

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -72,12 +72,16 @@ class SettingsService implements ISettingsService {
 
   @override
   Future<Result<void>> setPhotoTypeFilter(PhotoTypeFilter filter) async {
+    if (_preferences == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
     return ResultHelper.tryExecuteAsync(() async {
-      final prefs = _preferences;
-      if (prefs == null) {
-        throw const SettingsException('SettingsService is not initialized');
-      }
-      final saved = await prefs.setInt(_photoTypeFilterKey, filter.index);
+      final saved = await _preferences!.setInt(
+        _photoTypeFilterKey,
+        filter.index,
+      );
       if (!saved) {
         throw const SettingsException('Failed to persist photo type filter');
       }
@@ -106,13 +110,15 @@ class SettingsService implements ISettingsService {
 
   @override
   Future<Result<void>> setDiaryLength(DiaryLength length) async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final prefs = _preferences;
-      if (prefs == null) {
-        throw const SettingsException('SettingsService is not initialized');
-      }
-      await prefs.setInt(_diaryLengthKey, length.index);
-    }, context: 'SettingsService.setDiaryLength');
+    if (_preferences == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
+    return ResultHelper.tryExecuteAsync(
+      () async => _preferences!.setInt(_diaryLengthKey, length.index),
+      context: 'SettingsService.setDiaryLength',
+    );
   }
 
   // テーマモード
@@ -135,13 +141,15 @@ class SettingsService implements ISettingsService {
 
   @override
   Future<Result<void>> setThemeMode(ThemeMode themeMode) async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final prefs = _preferences;
-      if (prefs == null) {
-        throw const SettingsException('SettingsService is not initialized');
-      }
-      await prefs.setInt(_themeKey, themeMode.index);
-    }, context: 'SettingsService.setThemeMode');
+    if (_preferences == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
+    return ResultHelper.tryExecuteAsync(
+      () async => _preferences!.setInt(_themeKey, themeMode.index),
+      context: 'SettingsService.setThemeMode',
+    );
   }
 
   @override
@@ -154,15 +162,16 @@ class SettingsService implements ISettingsService {
 
   @override
   Future<Result<void>> setLocale(Locale? locale) async {
+    if (_preferences == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
     return ResultHelper.tryExecuteAsync(() async {
-      final prefs = _preferences;
-      if (prefs == null) {
-        throw const SettingsException('SettingsService is not initialized');
-      }
       if (locale == null) {
-        await prefs.remove(_localeKey);
+        await _preferences!.remove(_localeKey);
       } else {
-        await prefs.setString(_localeKey, _serializeLocale(locale));
+        await _preferences!.setString(_localeKey, _serializeLocale(locale));
       }
       _localeNotifier.value = locale;
     }, context: 'SettingsService.setLocale');
@@ -184,13 +193,15 @@ class SettingsService implements ISettingsService {
   // 初回起動完了を記録
   @override
   Future<Result<void>> setFirstLaunchCompleted() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final prefs = _preferences;
-      if (prefs == null) {
-        throw const SettingsException('SettingsService is not initialized');
-      }
-      await prefs.setBool(_firstLaunchKey, false);
-    }, context: 'SettingsService.setFirstLaunchCompleted');
+    if (_preferences == null) {
+      return const Failure(
+        SettingsException('SettingsService is not initialized'),
+      );
+    }
+    return ResultHelper.tryExecuteAsync(
+      () async => _preferences!.setBool(_firstLaunchKey, false),
+      context: 'SettingsService.setFirstLaunchCompleted',
+    );
   }
 
   Locale? _loadStoredLocale() => locale;
@@ -226,57 +237,51 @@ class SettingsService implements ISettingsService {
 
   // サブスクリプション状態管理API（SettingsSubscriptionDelegate に委譲）
 
-  /// delegate が初期化済みであることを保証してから返す
-  SettingsSubscriptionDelegate _requireDelegate() {
-    final delegate = _subscriptionDelegate;
-    if (delegate == null) {
-      throw StateError('SubscriptionService is not initialized');
-    }
-    return delegate;
-  }
-
   @override
   Future<Result<SubscriptionInfoV2>> getSubscriptionInfoV2() =>
-      _delegateOr(() => _requireDelegate().getSubscriptionInfoV2());
+      _delegateOr((d) => d.getSubscriptionInfoV2());
 
   @override
   Future<Result<Plan>> getCurrentPlanClass() =>
-      _delegateOr(() => _requireDelegate().getCurrentPlanClass());
+      _delegateOr((d) => d.getCurrentPlanClass());
 
   @override
   Future<Result<PlanPeriodInfoV2>> getPlanPeriodInfoV2() =>
-      _delegateOr(() => _requireDelegate().getPlanPeriodInfoV2());
+      _delegateOr((d) => d.getPlanPeriodInfoV2());
 
   @override
   Future<Result<AutoRenewalInfoV2>> getAutoRenewalInfo() =>
-      _delegateOr(() => _requireDelegate().getAutoRenewalInfo());
+      _delegateOr((d) => d.getAutoRenewalInfo());
 
   @override
   Future<Result<UsageStatisticsV2>> getUsageStatisticsWithPlanClass() =>
-      _delegateOr(() => _requireDelegate().getUsageStatisticsWithPlanClass());
+      _delegateOr((d) => d.getUsageStatisticsWithPlanClass());
 
   @override
   Future<Result<int>> getRemainingGenerations() =>
-      _delegateOr(() => _requireDelegate().getRemainingGenerations());
+      _delegateOr((d) => d.getRemainingGenerations());
 
   @override
   Future<Result<DateTime>> getNextResetDate() =>
-      _delegateOr(() => _requireDelegate().getNextResetDate());
+      _delegateOr((d) => d.getNextResetDate());
 
   @override
-  Future<Result<bool>> canChangePlan() =>
-      _delegateOr(() => _requireDelegate().canChangePlan());
+  Future<Result<bool>> canChangePlan() => _delegateOr((d) => d.canChangePlan());
 
   @override
   Future<Result<List<Plan>>> getAvailablePlansV2() =>
-      _delegateOr(() => _requireDelegate().getAvailablePlansV2());
+      _delegateOr((d) => d.getAvailablePlansV2());
 
-  /// delegate 未初期化時は Failure を返すラッパー
-  Future<Result<T>> _delegateOr<T>(Future<Result<T>> Function() fn) async {
-    try {
-      return await fn();
-    } on StateError catch (e) {
-      return Failure(ServiceException(e.message));
+  /// delegate 未初期化時は Failure を返す。null チェックをここに集約。
+  Future<Result<T>> _delegateOr<T>(
+    Future<Result<T>> Function(SettingsSubscriptionDelegate) fn,
+  ) async {
+    final delegate = _subscriptionDelegate;
+    if (delegate == null) {
+      return const Failure(
+        ServiceException('SubscriptionService is not initialized'),
+      );
     }
+    return fn(delegate);
   }
 }

--- a/lib/services/settings_subscription_delegate.dart
+++ b/lib/services/settings_subscription_delegate.dart
@@ -16,20 +16,11 @@ class SettingsSubscriptionDelegate {
     required ISubscriptionService subscriptionService,
   }) : _subscriptionService = subscriptionService;
 
-  /// Result から値を取り出す。Failure の場合は例外をスロー。
-  T _requireResult<T>(Result<T> result) {
-    if (result.isFailure) throw result.error;
-    return result.value;
-  }
-
   /// 包括的なサブスクリプション情報を取得（V2版）
   Future<Result<SubscriptionInfoV2>> getSubscriptionInfoV2() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final status = _requireResult(
-        await _subscriptionService.getCurrentStatus(),
-      );
-      return SubscriptionInfoV2.fromStatus(status);
-    }, context: 'SettingsSubscriptionDelegate.getSubscriptionInfoV2');
+    final statusResult = await _subscriptionService.getCurrentStatus();
+    if (statusResult.isFailure) return Failure(statusResult.error);
+    return Success(SubscriptionInfoV2.fromStatus(statusResult.value));
   }
 
   /// 現在のプラン情報を取得（Planクラス版）
@@ -38,40 +29,35 @@ class SettingsSubscriptionDelegate {
 
   /// プラン期限情報を取得（V2版）
   Future<Result<PlanPeriodInfoV2>> getPlanPeriodInfoV2() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final status = _requireResult(
-        await _subscriptionService.getCurrentStatus(),
-      );
-      final plan = _requireResult(
-        await _subscriptionService.getCurrentPlanClass(),
-      );
+    final statusResult = await _subscriptionService.getCurrentStatus();
+    if (statusResult.isFailure) return Failure(statusResult.error);
 
-      return PlanPeriodInfoV2.fromStatusAndPlan(status, plan);
-    }, context: 'SettingsSubscriptionDelegate.getPlanPeriodInfoV2');
+    final planResult = await _subscriptionService.getCurrentPlanClass();
+    if (planResult.isFailure) return Failure(planResult.error);
+
+    return Success(
+      PlanPeriodInfoV2.fromStatusAndPlan(statusResult.value, planResult.value),
+    );
   }
 
   /// 自動更新状態情報を取得
   Future<Result<AutoRenewalInfoV2>> getAutoRenewalInfo() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final status = _requireResult(
-        await _subscriptionService.getCurrentStatus(),
-      );
-      return AutoRenewalInfoV2.fromStatus(status);
-    }, context: 'SettingsSubscriptionDelegate.getAutoRenewalInfo');
+    final statusResult = await _subscriptionService.getCurrentStatus();
+    if (statusResult.isFailure) return Failure(statusResult.error);
+    return Success(AutoRenewalInfoV2.fromStatus(statusResult.value));
   }
 
   /// 使用統計情報を取得（Planクラス版）
   Future<Result<UsageStatisticsV2>> getUsageStatisticsWithPlanClass() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final status = _requireResult(
-        await _subscriptionService.getCurrentStatus(),
-      );
-      final plan = _requireResult(
-        await _subscriptionService.getCurrentPlanClass(),
-      );
+    final statusResult = await _subscriptionService.getCurrentStatus();
+    if (statusResult.isFailure) return Failure(statusResult.error);
 
-      return UsageStatisticsV2.fromStatusAndPlan(status, plan);
-    }, context: 'SettingsSubscriptionDelegate.getUsageStatisticsWithPlanClass');
+    final planResult = await _subscriptionService.getCurrentPlanClass();
+    if (planResult.isFailure) return Failure(planResult.error);
+
+    return Success(
+      UsageStatisticsV2.fromStatusAndPlan(statusResult.value, planResult.value),
+    );
   }
 
   /// 残り使用可能回数を取得
@@ -84,18 +70,15 @@ class SettingsSubscriptionDelegate {
 
   /// プラン変更可能かどうかを確認
   Future<Result<bool>> canChangePlan() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      // サービス正常性チェック（値は不要だが、失敗時にFailureを返すためのガード）
-      _requireResult(await _subscriptionService.getCurrentStatus());
-      return _subscriptionService.isInitialized;
-    }, context: 'SettingsSubscriptionDelegate.canChangePlan');
+    final statusResult = await _subscriptionService.getCurrentStatus();
+    if (statusResult.isFailure) return Failure(statusResult.error);
+    return Success(_subscriptionService.isInitialized);
   }
 
   /// プラン比較情報を取得（V2版）
-  Future<Result<List<Plan>>> getAvailablePlansV2() async {
-    return ResultHelper.tryExecuteAsync(() async {
-      final plans = PlanFactory.getAllPlans();
-      return plans;
-    }, context: 'SettingsSubscriptionDelegate.getAvailablePlansV2');
-  }
+  Future<Result<List<Plan>>> getAvailablePlansV2() =>
+      ResultHelper.tryExecuteAsync(
+        () async => PlanFactory.getAllPlans(),
+        context: 'SettingsSubscriptionDelegate.getAvailablePlansV2',
+      );
 }

--- a/lib/services/settings_subscription_delegate.dart
+++ b/lib/services/settings_subscription_delegate.dart
@@ -29,12 +29,12 @@ class SettingsSubscriptionDelegate {
 
   /// プラン期限情報を取得（V2版）
   Future<Result<PlanPeriodInfoV2>> getPlanPeriodInfoV2() async {
-    final statusResult = await _subscriptionService.getCurrentStatus();
+    final (statusResult, planResult) = await (
+      _subscriptionService.getCurrentStatus(),
+      _subscriptionService.getCurrentPlanClass(),
+    ).wait;
     if (statusResult.isFailure) return Failure(statusResult.error);
-
-    final planResult = await _subscriptionService.getCurrentPlanClass();
     if (planResult.isFailure) return Failure(planResult.error);
-
     return Success(
       PlanPeriodInfoV2.fromStatusAndPlan(statusResult.value, planResult.value),
     );
@@ -49,12 +49,12 @@ class SettingsSubscriptionDelegate {
 
   /// 使用統計情報を取得（Planクラス版）
   Future<Result<UsageStatisticsV2>> getUsageStatisticsWithPlanClass() async {
-    final statusResult = await _subscriptionService.getCurrentStatus();
+    final (statusResult, planResult) = await (
+      _subscriptionService.getCurrentStatus(),
+      _subscriptionService.getCurrentPlanClass(),
+    ).wait;
     if (statusResult.isFailure) return Failure(statusResult.error);
-
-    final planResult = await _subscriptionService.getCurrentPlanClass();
     if (planResult.isFailure) return Failure(planResult.error);
-
     return Success(
       UsageStatisticsV2.fromStatusAndPlan(statusResult.value, planResult.value),
     );

--- a/lib/services/social_share/channels/instagram_share_channel.dart
+++ b/lib/services/social_share/channels/instagram_share_channel.dart
@@ -69,7 +69,7 @@ class InstagramShareChannel with ShareChannelMixin {
                 (l10n) => l10n.commonShareTimeout,
                 'Sharing timed out',
               );
-              throw Exception(timeoutMessage);
+              throw InstagramShareException(timeoutMessage);
             },
           );
 

--- a/lib/services/social_share/channels/x_share_channel.dart
+++ b/lib/services/social_share/channels/x_share_channel.dart
@@ -97,7 +97,7 @@ class XShareChannel with ShareChannelMixin {
                 (l10n) => l10n.commonShareTimeout,
                 'Sharing timed out',
               );
-              throw Exception(timeoutMessage);
+              throw XShareException(timeoutMessage);
             },
           );
 

--- a/lib/services/storage_export_delegate.dart
+++ b/lib/services/storage_export_delegate.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:file_picker/file_picker.dart';
 
+import '../core/errors/app_exceptions.dart';
 import '../core/result/result.dart';
 import '../localization/localization_utils.dart';
 import 'interfaces/diary_service_interface.dart';
@@ -23,59 +24,69 @@ class StorageExportDelegate {
     DateTime? startDate,
     DateTime? endDate,
   }) async {
-    final diaryService = await _getDiaryService();
-    final result = await diaryService.getSortedDiaryEntries();
+    try {
+      final diaryService = await _getDiaryService();
+      final result = await diaryService.getSortedDiaryEntries();
 
-    if (result.isFailure) {
-      return Failure(result.error);
+      if (result.isFailure) {
+        return Failure(result.error);
+      }
+
+      var entries = result.value;
+
+      // 期間フィルター
+      if (startDate != null || endDate != null) {
+        entries = entries.where((entry) {
+          if (startDate != null && entry.date.isBefore(startDate)) return false;
+          if (endDate != null && entry.date.isAfter(endDate)) return false;
+          return true;
+        }).toList();
+      }
+
+      // JSON形式でエクスポート
+      final jsonData = {
+        'app_name': 'Smart Photo Diary',
+        'export_date': DateTime.now().toIso8601String(),
+        'version': '1.0.0',
+        'entries': entries
+            .map(
+              (entry) => {
+                'id': entry.id,
+                'title': entry.title,
+                'content': entry.content,
+                'date': entry.date.toIso8601String(),
+                'photoIds': entry.photoIds,
+                'tags': entry.effectiveTags,
+                'createdAt': entry.createdAt.toIso8601String(),
+                'updatedAt': entry.updatedAt.toIso8601String(),
+              },
+            )
+            .toList(),
+      };
+
+      final jsonString = const JsonEncoder.withIndent('  ').convert(jsonData);
+
+      // ファイル保存先を選択
+      final fileName =
+          'smart_diary_backup_${DateTime.now().millisecondsSinceEpoch}.json';
+      final l10n = LocalizationUtils.resolveFor(await _resolveLocale());
+      final outputFile = await FilePicker.saveFile(
+        dialogTitle: l10n.settingsBackupDialogTitle,
+        fileName: fileName,
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+        bytes: utf8.encode(jsonString),
+      );
+
+      return Success(outputFile);
+    } catch (e, st) {
+      return Failure(
+        StorageException(
+          'Failed to export data',
+          originalError: e,
+          stackTrace: st,
+        ),
+      );
     }
-
-    var entries = result.value;
-
-    // 期間フィルター
-    if (startDate != null || endDate != null) {
-      entries = entries.where((entry) {
-        if (startDate != null && entry.date.isBefore(startDate)) return false;
-        if (endDate != null && entry.date.isAfter(endDate)) return false;
-        return true;
-      }).toList();
-    }
-
-    // JSON形式でエクスポート
-    final jsonData = {
-      'app_name': 'Smart Photo Diary',
-      'export_date': DateTime.now().toIso8601String(),
-      'version': '1.0.0',
-      'entries': entries
-          .map(
-            (entry) => {
-              'id': entry.id,
-              'title': entry.title,
-              'content': entry.content,
-              'date': entry.date.toIso8601String(),
-              'photoIds': entry.photoIds,
-              'tags': entry.effectiveTags,
-              'createdAt': entry.createdAt.toIso8601String(),
-              'updatedAt': entry.updatedAt.toIso8601String(),
-            },
-          )
-          .toList(),
-    };
-
-    final jsonString = const JsonEncoder.withIndent('  ').convert(jsonData);
-
-    // ファイル保存先を選択
-    final fileName =
-        'smart_diary_backup_${DateTime.now().millisecondsSinceEpoch}.json';
-    final l10n = LocalizationUtils.resolveFor(await _resolveLocale());
-    final outputFile = await FilePicker.saveFile(
-      dialogTitle: l10n.settingsBackupDialogTitle,
-      fileName: fileName,
-      type: FileType.custom,
-      allowedExtensions: ['json'],
-      bytes: utf8.encode(jsonString),
-    );
-
-    return Success(outputFile);
   }
 }

--- a/lib/services/storage_export_delegate.dart
+++ b/lib/services/storage_export_delegate.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 
 import 'package:file_picker/file_picker.dart';
 
-import '../core/errors/app_exceptions.dart';
+import '../core/result/result.dart';
 import '../localization/localization_utils.dart';
 import 'interfaces/diary_service_interface.dart';
 
@@ -19,14 +19,15 @@ class StorageExportDelegate {
        _resolveLocale = resolveLocale;
 
   /// データのエクスポート（保存先選択可能）
-  Future<String?> exportData({DateTime? startDate, DateTime? endDate}) async {
+  Future<Result<String?>> exportData({
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
     final diaryService = await _getDiaryService();
     final result = await diaryService.getSortedDiaryEntries();
 
     if (result.isFailure) {
-      throw StorageException(
-        'Failed to retrieve diary data: ${result.error.message}',
-      );
+      return Failure(result.error);
     }
 
     var entries = result.value;
@@ -75,6 +76,6 @@ class StorageExportDelegate {
       bytes: utf8.encode(jsonString),
     );
 
-    return outputFile;
+    return Success(outputFile);
   }
 }

--- a/lib/services/storage_import_delegate.dart
+++ b/lib/services/storage_import_delegate.dart
@@ -148,9 +148,7 @@ class StorageImportDelegate {
       // パフォーマンス最適化: 既存エントリーを一度だけ取得
       final existingResult = await diaryService.getSortedDiaryEntries();
       if (existingResult.isFailure) {
-        throw StorageException(
-          'Failed to retrieve existing diary data: ${existingResult.error.message}',
-        );
+        return Failure(existingResult.error);
       }
       final existingEntries = existingResult.value;
       // インポート済みエントリーの追跡用セット（同一バックアップ内の重複検出）
@@ -288,9 +286,7 @@ class StorageImportDelegate {
       );
 
       if (saveResult.isFailure) {
-        throw StorageException(
-          'Failed to save entry: ${saveResult.error.message}',
-        );
+        return Failure(saveResult.error);
       }
 
       // インポート済みセットを更新（同一バックアップ内の後続重複を検出するため）

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -44,11 +44,13 @@ class StorageService implements IStorageService {
 
   /// DiaryService を取得
   Future<IDiaryService> _getDiaryService() async {
-    assert(
-      _diaryService != null,
-      'StorageService: diaryService is not injected. Ensure it is provided via constructor.',
-    );
-    return _diaryService!;
+    final diaryService = _diaryService;
+    if (diaryService == null) {
+      throw StateError(
+        'StorageService: diaryService is not injected. Ensure it is provided via constructor.',
+      );
+    }
+    return diaryService;
   }
 
   /// 現在のロケールを解決する

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -44,13 +44,11 @@ class StorageService implements IStorageService {
 
   /// DiaryService を取得
   Future<IDiaryService> _getDiaryService() async {
-    if (_diaryService == null) {
-      throw StateError(
-        'StorageService: diaryService is not injected. '
-        'Ensure it is provided via constructor.',
-      );
-    }
-    return _diaryService;
+    assert(
+      _diaryService != null,
+      'StorageService: diaryService is not injected. Ensure it is provided via constructor.',
+    );
+    return _diaryService!;
   }
 
   /// 現在のロケールを解決する
@@ -103,7 +101,12 @@ class StorageService implements IStorageService {
   // データのエクスポート（保存先選択可能）
   @override
   Future<String?> exportData({DateTime? startDate, DateTime? endDate}) async {
-    return _exportDelegate.exportData(startDate: startDate, endDate: endDate);
+    final result = await exportDataResult(
+      startDate: startDate,
+      endDate: endDate,
+    );
+    if (result.isFailure) throw result.error;
+    return result.value;
   }
 
   // データのインポート（リストア機能）
@@ -188,16 +191,7 @@ class StorageService implements IStorageService {
   Future<Result<String?>> exportDataResult({
     DateTime? startDate,
     DateTime? endDate,
-  }) async {
-    try {
-      final result = await exportData(startDate: startDate, endDate: endDate);
-      return Success(result);
-    } catch (e) {
-      return Failure(
-        ServiceException('Failed to export data', originalError: e),
-      );
-    }
-  }
+  }) => _exportDelegate.exportData(startDate: startDate, endDate: endDate);
 
   /// データベースの最適化（Result版）
   @override

--- a/test/unit/services/prompt_service_test.dart
+++ b/test/unit/services/prompt_service_test.dart
@@ -547,17 +547,14 @@ void main() {
 
     group('エラーハンドリング', () {
       test('初期化前のメソッド呼び出しでエラーが発生', () {
-        expect(
-          () => promptService.getAllPrompts(),
-          throwsA(isA<AssertionError>()),
-        );
+        expect(() => promptService.getAllPrompts(), throwsA(isA<StateError>()));
         expect(
           () => promptService.getPromptsForPlan(isPremium: true),
-          throwsA(isA<AssertionError>()),
+          throwsA(isA<StateError>()),
         );
         expect(
           () => promptService.getRandomPrompt(isPremium: true),
-          throwsA(isA<AssertionError>()),
+          throwsA(isA<StateError>()),
         );
       });
     });

--- a/test/unit/services/prompt_service_test.dart
+++ b/test/unit/services/prompt_service_test.dart
@@ -547,14 +547,17 @@ void main() {
 
     group('エラーハンドリング', () {
       test('初期化前のメソッド呼び出しでエラーが発生', () {
-        expect(() => promptService.getAllPrompts(), throwsStateError);
+        expect(
+          () => promptService.getAllPrompts(),
+          throwsA(isA<AssertionError>()),
+        );
         expect(
           () => promptService.getPromptsForPlan(isPremium: true),
-          throwsStateError,
+          throwsA(isA<AssertionError>()),
         );
         expect(
           () => promptService.getRandomPrompt(isPremium: true),
-          throwsStateError,
+          throwsA(isA<AssertionError>()),
         );
       });
     });

--- a/test/unit/services/purchase_flow_delegate_test.dart
+++ b/test/unit/services/purchase_flow_delegate_test.dart
@@ -120,6 +120,25 @@ void main() {
       );
     });
 
+    test('queryProductDetailsがFailure → Failureを返して購入フラグを戻す', () async {
+      when(() => mockStateService.isInitialized).thenReturn(true);
+
+      when(() => mockProductDelegate.queryProductDetails(any())).thenAnswer(
+        (_) async => const Failure(ServiceException('lookup failed')),
+      );
+
+      final result = await delegate.purchasePlan(PremiumMonthlyPlan());
+
+      expect(result.isFailure, isTrue);
+      expect(result.error.toString(), contains('lookup failed'));
+      expect(isPurchasing, isFalse);
+      verifyNever(
+        () => mockInAppPurchase.buyNonConsumable(
+          purchaseParam: any(named: 'purchaseParam'),
+        ),
+      );
+    });
+
     test('正常系 → Success(pending)', () async {
       when(() => mockStateService.isInitialized).thenReturn(true);
       final fakeProduct = FakeProductDetails();

--- a/test/unit/services/purchase_flow_delegate_test.dart
+++ b/test/unit/services/purchase_flow_delegate_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
+import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/services/purchase_flow_delegate.dart';
 import 'package:smart_photo_diary/services/purchase_product_delegate.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
@@ -125,7 +126,7 @@ void main() {
 
       when(
         () => mockProductDelegate.queryProductDetails(any()),
-      ).thenAnswer((_) async => fakeProduct);
+      ).thenAnswer((_) async => Success(fakeProduct));
 
       when(
         () => mockInAppPurchase.buyNonConsumable(
@@ -146,7 +147,7 @@ void main() {
 
       when(
         () => mockProductDelegate.queryProductDetails(any()),
-      ).thenAnswer((_) async => fakeProduct);
+      ).thenAnswer((_) async => Success(fakeProduct));
 
       when(
         () => mockInAppPurchase.buyNonConsumable(

--- a/test/unit/services/purchase_product_delegate_test.dart
+++ b/test/unit/services/purchase_product_delegate_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
-import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/services/purchase_product_delegate.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';

--- a/test/unit/services/purchase_product_delegate_test.dart
+++ b/test/unit/services/purchase_product_delegate_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/services/purchase_product_delegate.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
@@ -224,7 +225,7 @@ void main() {
   });
 
   group('queryProductDetails', () {
-    test('クエリエラー → ServiceException', () async {
+    test('クエリエラー → Failure(ServiceException)', () async {
       when(() => mockStateService.isInitialized).thenReturn(true);
 
       when(() => mockInAppPurchase.queryProductDetails(any())).thenAnswer(
@@ -239,15 +240,14 @@ void main() {
         ),
       );
 
-      expect(
-        () => delegate.queryProductDetails(
-          'smart_photo_diary_premium_monthly_plan',
-        ),
-        throwsA(isA<ServiceException>()),
+      final result = await delegate.queryProductDetails(
+        'smart_photo_diary_premium_monthly_plan',
       );
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<ServiceException>());
     });
 
-    test('商品が見つからない → ServiceException', () async {
+    test('商品が見つからない → Failure(ServiceException)', () async {
       when(() => mockStateService.isInitialized).thenReturn(true);
 
       when(() => mockInAppPurchase.queryProductDetails(any())).thenAnswer(
@@ -257,12 +257,11 @@ void main() {
         ),
       );
 
-      expect(
-        () => delegate.queryProductDetails(
-          'smart_photo_diary_premium_monthly_plan',
-        ),
-        throwsA(isA<ServiceException>()),
+      final result = await delegate.queryProductDetails(
+        'smart_photo_diary_premium_monthly_plan',
       );
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<ServiceException>());
     });
   });
 }


### PR DESCRIPTION
## Summary

- Replace `throw` statements in service methods with `return Failure(...)` to enforce `Result<T>` contract throughout the service layer
- Fix `StorageExportDelegate.exportData()` to return `Result<String?>` with proper try-catch wrapping
- Fix `StorageImportDelegate` to propagate failures via `Failure` instead of rethrowing
- Fix `PurchaseProductDelegate.queryProductDetails()` to return `Result<ProductDetails>` instead of throwing
- Update `PurchaseFlowDelegate` caller to handle new `Result`-based `queryProductDetails`
- Replace `ArgumentError` with `ServiceException` in `PurchaseEventHandler` for consistent exception hierarchy
- Replace typed `Exception` with domain exceptions (`XShareException`, `InstagramShareException`) in social share channels
- Refactor `SettingsService._delegateOr` and `_withPreferences` helpers to eliminate double-wrapping anti-pattern
- Parallelize independent async calls in `SettingsSubscriptionDelegate` using Dart 3 record `.wait`
- Replace `assert` with `throw StateError` in `PromptService._ensureInitialized` for production-safe guard

## Test Plan

- All 1997 tests pass: `fvm flutter test`
- No analysis issues: `fvm flutter analyze`
- Verify `Result<T>` callers handle both `Success` and `Failure` paths without try-catch fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 購入フロー、設定管理、データエクスポート時のエラーハンドリングを統一し、より一貫した例外管理を実現しました。エラー処理がより堅牢になりました。

* **Tests**
  * 改善されたエラーハンドリング機構に対応するテストを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->