### PR TITLE
refactor: complete ServiceLocator elimination from non-composition-root code

### DIFF
--- a/lib/config/environment_config.dart
+++ b/lib/config/environment_config.dart
@@ -2,12 +2,16 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../constants/subscription_constants.dart';
 import '../services/interfaces/logging_service_interface.dart';
-import '../core/service_locator.dart';
 
 /// 環境変数を安全に管理するクラス
 class EnvironmentConfig {
-  static ILoggingService get _logger => serviceLocator.get<ILoggingService>();
+  static ILoggingService? _logger;
   static bool _isInitialized = false;
+
+  static void configure(ILoggingService logger) {
+    _logger = logger;
+  }
+
   static String? _cachedGeminiApiKey;
   static String? _cachedForcePlan;
 
@@ -20,7 +24,7 @@ class EnvironmentConfig {
         defaultValue: '',
       );
 
-      _logger.info(
+      _logger?.info(
         'API key source: ${_cachedGeminiApiKey!.isEmpty ? ".env file" : "build-time constants"}',
         context: 'EnvironmentConfig.initialize',
       );
@@ -31,12 +35,12 @@ class EnvironmentConfig {
           // プロジェクトルートから読み込み（セキュリティを考慮）
           await dotenv.load(fileName: '.env');
           _cachedGeminiApiKey = dotenv.env['GEMINI_API_KEY'] ?? '';
-          _logger.info(
+          _logger?.info(
             'Development: loaded from .env file',
             context: 'EnvironmentConfig.initialize',
           );
         } catch (e) {
-          _logger.warning(
+          _logger?.warning(
             'Failed to load .env file (development)',
             context: 'EnvironmentConfig.initialize',
             data: {'error': e.toString()},
@@ -66,16 +70,16 @@ class EnvironmentConfig {
 
       _isInitialized = true;
 
-      _logger.info(
+      _logger?.info(
         'EnvironmentConfig initialization completed',
         context: 'EnvironmentConfig.initialize',
       );
-      _logger.info(
+      _logger?.info(
         'API key source: ${_cachedGeminiApiKey!.isEmpty ? "not set" : (kDebugMode ? "development" : "production")}',
         context: 'EnvironmentConfig.initialize',
       );
     } catch (e) {
-      _logger.error(
+      _logger?.error(
         'Environment config initialization error',
         context: 'EnvironmentConfig.initialize',
         error: e,
@@ -87,7 +91,7 @@ class EnvironmentConfig {
   /// Gemini APIキーを取得
   static String get geminiApiKey {
     if (!_isInitialized) {
-      _logger.warning(
+      _logger?.warning(
         'EnvironmentConfig is not initialized',
         context: 'EnvironmentConfig.geminiApiKey',
       );
@@ -101,7 +105,7 @@ class EnvironmentConfig {
 
     final key = _cachedGeminiApiKey ?? '';
     if (key.isEmpty) {
-      _logger.warning(
+      _logger?.warning(
         'GEMINI_API_KEY is not set',
         context: 'EnvironmentConfig.geminiApiKey',
       );
@@ -150,7 +154,7 @@ class EnvironmentConfig {
       return plan;
     }
 
-    _logger.warning(
+    _logger?.warning(
       'Invalid FORCE_PLAN specified',
       context: 'EnvironmentConfig.forcePlan',
       data: {'invalidPlan': plan, 'validPlans': validPlans.toList()},
@@ -174,7 +178,7 @@ class EnvironmentConfig {
 
   /// デバッグ情報を出力
   static void printDebugInfo() {
-    _logger.debug(
+    _logger?.debug(
       'Environment Config Debug Info',
       context: 'EnvironmentConfig.printDebugInfo',
       data: {

--- a/lib/controllers/diary_detail_controller.dart
+++ b/lib/controllers/diary_detail_controller.dart
@@ -14,6 +14,11 @@ enum DiaryDetailErrorType { notFound, loadFailed, updateFailed, deleteFailed }
 
 /// DiaryDetailScreen の状態管理・ビジネスロジック
 class DiaryDetailController extends BaseErrorController {
+  final ILoggingService _logger;
+
+  DiaryDetailController({ILoggingService? logger})
+    : _logger = logger ?? serviceLocator.get<ILoggingService>();
+
   DiaryEntry? _diaryEntry;
   List<AssetEntity> _photoAssets = [];
   bool _isEditing = false;
@@ -86,16 +91,12 @@ class DiaryDetailController extends BaseErrorController {
           if (localVersion != _requestVersion) return;
 
           if (assetsResult.isFailure) {
-            try {
-              serviceLocator.get<ILoggingService>().warning(
-                'Failed to load photo assets for diary entry',
-                context: 'DiaryDetailController.loadDiaryEntry',
-                data:
-                    'diaryId: ${entry.id}, error: ${assetsResult.error.message}',
-              );
-            } catch (_) {
-              // LoggingService unavailable — non-critical, photo loading continues with fallback
-            }
+            _logger.warning(
+              'Failed to load photo assets for diary entry',
+              context: 'DiaryDetailController.loadDiaryEntry',
+              data:
+                  'diaryId: ${entry.id}, error: ${assetsResult.error.message}',
+            );
           }
 
           _diaryEntry = entry;

--- a/lib/controllers/onboarding_controller.dart
+++ b/lib/controllers/onboarding_controller.dart
@@ -15,7 +15,10 @@ class OnboardingController extends ChangeNotifier {
   bool _isProcessing = false;
   bool _disposed = false;
 
-  ILoggingService get _logger => serviceLocator.get<ILoggingService>();
+  final ILoggingService _logger;
+
+  OnboardingController({ILoggingService? logger})
+    : _logger = logger ?? serviceLocator.get<ILoggingService>();
 
   int get currentPage => _currentPage;
   bool get isProcessing => _isProcessing;

--- a/lib/controllers/statistics_controller.dart
+++ b/lib/controllers/statistics_controller.dart
@@ -12,7 +12,8 @@ import 'base_error_controller.dart';
 
 /// StatisticsScreen の状態管理・ビジネスロジック
 class StatisticsController extends BaseErrorController {
-  late final ILoggingService _logger;
+  final ILoggingService _logger;
+  final IDiaryService? _injectedDiaryService;
 
   List<DiaryEntry> _allDiaries = [];
   StatisticsData _stats = const StatisticsData(
@@ -39,16 +40,21 @@ class StatisticsController extends BaseErrorController {
   /// カレンダーの選択日
   DateTime? get selectedDay => _selectedDay;
 
-  StatisticsController() {
-    _logger = serviceLocator.get<ILoggingService>();
-  }
+  IDiaryService? _cachedDiaryService;
+
+  StatisticsController({ILoggingService? logger, IDiaryService? diaryService})
+    : _logger = logger ?? serviceLocator.get<ILoggingService>(),
+      _injectedDiaryService = diaryService;
+
+  Future<IDiaryService> _getDiaryService() async => _cachedDiaryService ??=
+      _injectedDiaryService ?? await serviceLocator.getAsync<IDiaryService>();
 
   /// 統計データを読み込む
   Future<void> loadStatistics() async {
     setLoading(true);
 
     try {
-      final diaryService = await serviceLocator.getAsync<IDiaryService>();
+      final diaryService = await _getDiaryService();
       final result = await diaryService.getSortedDiaryEntries();
 
       if (result.isSuccess) {
@@ -83,7 +89,7 @@ class StatisticsController extends BaseErrorController {
   /// 日記変更ストリームを購読する
   Future<void> subscribeDiaryChanges() async {
     try {
-      final diaryService = await serviceLocator.getAsync<IDiaryService>();
+      final diaryService = await _getDiaryService();
       _diarySub = diaryService.changes.listen((_) {
         _debounce?.cancel();
         _debounce = Timer(AppConstants.statisticsDebounce, () {

--- a/lib/core/service_registration.dart
+++ b/lib/core/service_registration.dart
@@ -235,8 +235,8 @@ class ServiceRegistration {
     serviceLocator.registerAsyncFactory<ISettingsService>(() async {
       final subscriptionService = await serviceLocator
           .getAsync<ISubscriptionService>();
-      final service = SettingsService();
-      await service.initialize(subscriptionService: subscriptionService);
+      final service = SettingsService(subscriptionService: subscriptionService);
+      await service.initialize();
       return service;
     });
 

--- a/lib/core/service_registration.dart
+++ b/lib/core/service_registration.dart
@@ -45,6 +45,10 @@ import 'errors/error_handler.dart';
 import 'hive_encryption_helper.dart';
 import 'service_locator.dart';
 import '../ui/error_display/error_display_service.dart';
+import '../utils/performance_monitor.dart';
+import '../utils/dynamic_pricing_utils.dart';
+import '../config/environment_config.dart';
+import '../screens/diary_preview/diary_preview_dialogs.dart';
 
 /// Service registration configuration
 ///
@@ -164,6 +168,10 @@ class ServiceRegistration {
     // ErrorHandler にロガーを注入（ServiceLocator直接依存を排除）
     ErrorHandler.configure(logger: loggingService);
     ErrorDisplayService.configure(logger: loggingService);
+    PerformanceMonitor.configure(loggingService);
+    EnvironmentConfig.configure(loggingService);
+    DynamicPricingUtils.configure(loggingService);
+    DiaryPreviewDialogHelper.configure(loggingService);
 
     _logger.debug(
       'Starting core service registration',
@@ -225,8 +233,10 @@ class ServiceRegistration {
 
     // 7. SettingsService (SubscriptionServiceに依存)
     serviceLocator.registerAsyncFactory<ISettingsService>(() async {
+      final subscriptionService = await serviceLocator
+          .getAsync<ISubscriptionService>();
       final service = SettingsService();
-      await service.initialize();
+      await service.initialize(subscriptionService: subscriptionService);
       return service;
     });
 

--- a/lib/debug/font_debug_screen.dart
+++ b/lib/debug/font_debug_screen.dart
@@ -5,7 +5,9 @@ import '../core/service_locator.dart';
 
 /// フォントデバッグ用の画面
 class FontDebugScreen extends StatefulWidget {
-  const FontDebugScreen({super.key});
+  const FontDebugScreen({super.key, this.logger});
+
+  final ILoggingService? logger;
 
   @override
   State<FontDebugScreen> createState() => _FontDebugScreenState();
@@ -14,8 +16,8 @@ class FontDebugScreen extends StatefulWidget {
 class _FontDebugScreenState extends State<FontDebugScreen> {
   List<String> systemFonts = [];
 
-  // LoggingServiceのゲッター
-  ILoggingService get _logger => serviceLocator.get<ILoggingService>();
+  ILoggingService get _logger =>
+      widget.logger ?? serviceLocator.get<ILoggingService>();
 
   @override
   void initState() {

--- a/lib/screens/diary_preview/diary_preview_dialogs.dart
+++ b/lib/screens/diary_preview/diary_preview_dialogs.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../core/service_locator.dart';
 import '../../core/service_registration.dart';
 import '../../localization/localization_extensions.dart';
 import '../../models/plans/basic_plan.dart';
@@ -14,6 +13,12 @@ import '../../utils/upgrade_dialog_utils.dart';
 /// 使用量制限ダイアログ、破棄確認ダイアログ、アップグレード誘導を担当する。
 class DiaryPreviewDialogHelper {
   DiaryPreviewDialogHelper._();
+
+  static ILoggingService? _logger;
+
+  static void configure(ILoggingService logger) {
+    _logger = logger;
+  }
 
   /// 日記破棄の確認ダイアログを表示
   static Future<bool> showDiscardConfirmationDialog(
@@ -70,9 +75,8 @@ class DiaryPreviewDialogHelper {
         );
       }
     } catch (e) {
-      final loggingService = serviceLocator.get<ILoggingService>();
-      loggingService.warning(
-        '使用量制限ダイアログ表示エラー',
+      _logger?.warning(
+        'Failed to show usage limit dialog',
         context: 'DiaryPreviewScreen._showUsageLimitDialog',
         data: e.toString(),
       );

--- a/lib/screens/diary_preview/diary_preview_generating.dart
+++ b/lib/screens/diary_preview/diary_preview_generating.dart
@@ -85,9 +85,10 @@ class DiaryPreviewGeneratingScreen extends StatelessWidget {
 }
 
 class _HeroPhoto extends StatefulWidget {
-  const _HeroPhoto({required this.asset});
+  const _HeroPhoto({required this.asset, this.cacheService});
 
   final AssetEntity asset;
+  final IPhotoCacheService? cacheService;
 
   @override
   State<_HeroPhoto> createState() => _HeroPhotoState();
@@ -99,7 +100,9 @@ class _HeroPhotoState extends State<_HeroPhoto> {
   @override
   void initState() {
     super.initState();
-    _future = serviceLocator.get<IPhotoCacheService>().getThumbnail(
+    final cacheService =
+        widget.cacheService ?? serviceLocator.get<IPhotoCacheService>();
+    _future = cacheService.getThumbnail(
       widget.asset,
       width: 800,
       height: 600,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -15,7 +15,7 @@ import 'settings_subscription_delegate.dart';
 class SettingsService implements ISettingsService {
   SharedPreferences? _preferences;
 
-  ISubscriptionService? _subscriptionService;
+  final ISubscriptionService _subscriptionService;
   SettingsSubscriptionDelegate? _subscriptionDelegate;
 
   static const String _localeKey = 'app_locale';
@@ -24,19 +24,16 @@ class SettingsService implements ISettingsService {
   final ValueNotifier<PhotoTypeFilter> _photoTypeFilterNotifier =
       ValueNotifier<PhotoTypeFilter>(PhotoTypeFilter.all);
 
-  /// DI用の公開コンストラクタ
-  SettingsService();
+  SettingsService({required ISubscriptionService subscriptionService})
+    : _subscriptionService = subscriptionService;
 
   /// DI用の非同期初期化
-  Future<void> initialize({
-    required ISubscriptionService subscriptionService,
-  }) async {
+  Future<void> initialize() async {
     _preferences ??= await SharedPreferences.getInstance();
     _localeNotifier.value = _loadStoredLocale();
     _photoTypeFilterNotifier.value = _loadStoredPhotoTypeFilter();
-    _subscriptionService = subscriptionService;
-    _subscriptionDelegate ??= SettingsSubscriptionDelegate(
-      subscriptionService: _subscriptionService!,
+    _subscriptionDelegate = SettingsSubscriptionDelegate(
+      subscriptionService: _subscriptionService,
     );
   }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -10,7 +10,6 @@ import '../models/subscription_info_v2.dart';
 import '../models/plans/plan.dart';
 import 'interfaces/settings_service_interface.dart';
 import 'interfaces/subscription_service_interface.dart';
-import '../core/service_locator.dart';
 import 'settings_subscription_delegate.dart';
 
 class SettingsService implements ISettingsService {
@@ -29,12 +28,13 @@ class SettingsService implements ISettingsService {
   SettingsService();
 
   /// DI用の非同期初期化
-  Future<void> initialize() async {
+  Future<void> initialize({
+    required ISubscriptionService subscriptionService,
+  }) async {
     _preferences ??= await SharedPreferences.getInstance();
     _localeNotifier.value = _loadStoredLocale();
     _photoTypeFilterNotifier.value = _loadStoredPhotoTypeFilter();
-    _subscriptionService ??= await serviceLocator
-        .getAsync<ISubscriptionService>();
+    _subscriptionService = subscriptionService;
     _subscriptionDelegate ??= SettingsSubscriptionDelegate(
       subscriptionService: _subscriptionService!,
     );

--- a/lib/ui/components/fullscreen_photo_viewer.dart
+++ b/lib/ui/components/fullscreen_photo_viewer.dart
@@ -22,8 +22,10 @@ class FullscreenPhotoViewer {
     BuildContext context, {
     required AssetEntity asset,
     required String heroTag,
+    IPhotoCacheService? cacheService,
   }) {
-    final cacheService = serviceLocator.get<IPhotoCacheService>();
+    final resolvedCacheService =
+        cacheService ?? serviceLocator.get<IPhotoCacheService>();
 
     showGeneralDialog(
       context: context,
@@ -45,7 +47,7 @@ class FullscreenPhotoViewer {
                 child: Hero(
                   tag: heroTag,
                   child: FutureBuilder<Result<Uint8List>>(
-                    future: cacheService.getThumbnail(
+                    future: resolvedCacheService.getThumbnail(
                       asset,
                       width: PhotoPreviewConstants.previewSizePx,
                       height: PhotoPreviewConstants.previewSizePx,

--- a/lib/utils/dynamic_pricing_utils.dart
+++ b/lib/utils/dynamic_pricing_utils.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import '../services/interfaces/subscription_service_interface.dart';
 import '../services/interfaces/logging_service_interface.dart';
-import '../core/service_locator.dart';
 import '../core/result/result.dart';
 import '../core/errors/app_exceptions.dart';
+import '../core/service_registration.dart';
 import '../models/plans/plan_factory.dart';
 import '../constants/app_constants.dart';
 import '../constants/subscription_constants.dart';
@@ -20,32 +20,38 @@ class DynamicPricingUtils {
   /// 複数プラン価格取得のデフォルトタイムアウト
   static const Duration multiplePlanTimeout = Duration(seconds: 10);
 
-  // LoggingServiceのゲッター
-  static ILoggingService get _logger => serviceLocator.get<ILoggingService>();
+  static ILoggingService? _logger;
+
+  static void configure(ILoggingService logger) {
+    _logger = logger;
+  }
 
   /// 指定プランの動的価格を取得（フォールバック付き）
   ///
   /// [planId] 取得するプランのID
   /// [locale] ロケール情報（フォールバック時に使用）
+  /// [subscriptionService] 注入するサービス（省略時はServiceRegistrationから取得）
   ///
   /// Returns: 動的価格（成功時）またはフォールバック価格（失敗時）
   static Future<String> getPlanPrice(
     String planId, {
     String? locale,
     Duration timeout = singlePlanTimeout,
+    ISubscriptionService? subscriptionService,
   }) async {
     try {
-      _logger.debug(
+      _logger?.debug(
         'Fetching dynamic price for plan: $planId',
         context: 'DynamicPricingUtils.getPlanPrice',
       );
 
       // SubscriptionServiceを取得
-      final subscriptionService = await serviceLocator
-          .getAsync<ISubscriptionService>();
+      final resolvedService =
+          subscriptionService ??
+          await ServiceRegistration.getAsync<ISubscriptionService>();
 
       // 動的価格を取得（タイムアウト付き）
-      final result = await subscriptionService
+      final result = await resolvedService
           .getProductPrice(planId)
           .timeout(
             timeout,
@@ -64,7 +70,7 @@ class DynamicPricingUtils {
           locale: locale,
         );
 
-        _logger.debug(
+        _logger?.debug(
           'Successfully using dynamic price for $planId',
           context: 'DynamicPricingUtils.getPlanPrice',
           data:
@@ -94,7 +100,7 @@ class DynamicPricingUtils {
     Duration timeout = multiplePlanTimeout,
   }) async {
     try {
-      _logger.debug(
+      _logger?.debug(
         'Fetching multiple plan prices',
         context: 'DynamicPricingUtils.getMultiplePlanPrices',
         data: 'plans=${planIds.join(", ")}',
@@ -113,7 +119,7 @@ class DynamicPricingUtils {
         priceMap[planIds[i]] = priceResults[i];
       }
 
-      _logger.debug(
+      _logger?.debug(
         'Successfully fetched multiple plan prices',
         context: 'DynamicPricingUtils.getMultiplePlanPrices',
         data: 'results=${priceMap.toString()}',
@@ -121,7 +127,7 @@ class DynamicPricingUtils {
 
       return priceMap;
     } catch (e) {
-      _logger.error(
+      _logger?.error(
         'Failed to fetch multiple plan prices',
         context: 'DynamicPricingUtils.getMultiplePlanPrices',
         error: e,
@@ -147,7 +153,7 @@ class DynamicPricingUtils {
       locale ?? 'ja',
     );
 
-    _logger.info(
+    _logger?.info(
       'Using fallback price for $planId',
       context: 'DynamicPricingUtils._getFallbackPrice',
       data: 'fallback_price=$fallbackPrice, error=${error.toString()}',

--- a/lib/utils/performance_monitor.dart
+++ b/lib/utils/performance_monitor.dart
@@ -1,15 +1,17 @@
 import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 import '../services/interfaces/logging_service_interface.dart';
-import '../core/service_locator.dart';
 
 /// パフォーマンス監視ユーティリティ
 class PerformanceMonitor {
   static final Map<String, DateTime> _startTimes = {};
   static final Map<String, List<double>> _measurements = {};
 
-  // LoggingServiceのゲッター
-  static ILoggingService get _logger => serviceLocator.get<ILoggingService>();
+  static ILoggingService? _logger;
+
+  static void configure(ILoggingService logger) {
+    _logger = logger;
+  }
 
   /// パフォーマンス計測を開始
   static void startMeasurement(String label) {
@@ -25,7 +27,7 @@ class PerformanceMonitor {
   static Future<void> endMeasurement(String label, {String? context}) async {
     final startTime = _startTimes[label];
     if (startTime == null) {
-      _logger.warning(
+      _logger?.warning(
         'Measurement not started: $label',
         context: 'PerformanceMonitor.endMeasurement',
       );
@@ -49,7 +51,7 @@ class PerformanceMonitor {
     _startTimes.remove(label);
 
     // ログに記録
-    _logger.debug(
+    _logger?.debug(
       'Performance: $label: ${milliseconds}ms (avg: ${average.toStringAsFixed(1)}ms)',
       context: context ?? 'PerformanceMonitor.endMeasurement',
     );
@@ -70,7 +72,7 @@ class PerformanceMonitor {
       });
     }
 
-    _logger.debug(
+    _logger?.debug(
       'Memory usage recorded',
       context: context,
       data: 'Check in Flutter DevTools',

--- a/lib/utils/upgrade_dialog_utils.dart
+++ b/lib/utils/upgrade_dialog_utils.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../core/service_locator.dart';
+import '../core/service_registration.dart';
 import '../services/interfaces/subscription_service_interface.dart';
 import '../services/interfaces/logging_service_interface.dart';
 import '../controllers/upgrade_dialog_controller.dart';
@@ -15,17 +15,22 @@ class UpgradeDialogUtils {
   UpgradeDialogUtils._();
 
   /// プレミアムプラン選択ダイアログを表示
-  static Future<void> showUpgradeDialog(BuildContext context) async {
-    final logger = serviceLocator.get<ILoggingService>();
+  static Future<void> showUpgradeDialog(
+    BuildContext context, {
+    ILoggingService? logger,
+    ISubscriptionService? subscriptionService,
+  }) async {
+    final resolvedLogger = logger ?? ServiceRegistration.get<ILoggingService>();
     final locale = context.l10n.localeName;
 
     try {
-      final subscriptionService = await serviceLocator
-          .getAsync<ISubscriptionService>();
+      final resolvedSubscriptionService =
+          subscriptionService ??
+          await ServiceRegistration.getAsync<ISubscriptionService>();
 
       final controller = UpgradeDialogController(
-        logger: logger,
-        subscriptionService: subscriptionService,
+        logger: resolvedLogger,
+        subscriptionService: resolvedSubscriptionService,
       );
 
       try {
@@ -42,7 +47,7 @@ class UpgradeDialogUtils {
 
         if (!context.mounted) return;
 
-        logger.debug(
+        resolvedLogger.debug(
           'Opening plan selection dialog with dynamic pricing',
           context: 'UpgradeDialogUtils.showUpgradeDialog',
         );
@@ -56,7 +61,7 @@ class UpgradeDialogUtils {
           ),
         );
 
-        logger.debug(
+        resolvedLogger.debug(
           'Plan selection dialog completed',
           context: 'UpgradeDialogUtils.showUpgradeDialog',
         );

--- a/lib/utils/upgrade_dialog_utils.dart
+++ b/lib/utils/upgrade_dialog_utils.dart
@@ -20,10 +20,11 @@ class UpgradeDialogUtils {
     ILoggingService? logger,
     ISubscriptionService? subscriptionService,
   }) async {
-    final resolvedLogger = logger ?? ServiceRegistration.get<ILoggingService>();
     final locale = context.l10n.localeName;
 
     try {
+      final resolvedLogger =
+          logger ?? ServiceRegistration.get<ILoggingService>();
       final resolvedSubscriptionService =
           subscriptionService ??
           await ServiceRegistration.getAsync<ISubscriptionService>();

--- a/test/unit/controllers/onboarding_controller_test.dart
+++ b/test/unit/controllers/onboarding_controller_test.dart
@@ -1,12 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:smart_photo_diary/controllers/onboarding_controller.dart';
+import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
+
+class _MockLogger extends Mock implements ILoggingService {}
 
 void main() {
   late OnboardingController controller;
   bool manuallyDisposed = false;
 
   setUp(() {
-    controller = OnboardingController();
+    controller = OnboardingController(logger: _MockLogger());
     manuallyDisposed = false;
   });
 

--- a/test/unit/services/settings_service_test.dart
+++ b/test/unit/services/settings_service_test.dart
@@ -29,8 +29,8 @@ void main() {
     mockSubscriptionService = MockSubscriptionServiceInterface();
     when(() => mockSubscriptionService.isInitialized).thenReturn(true);
 
-    service = SettingsService();
-    await service.initialize(subscriptionService: mockSubscriptionService);
+    service = SettingsService(subscriptionService: mockSubscriptionService);
+    await service.initialize();
   });
 
   tearDown(() {
@@ -260,12 +260,13 @@ void main() {
 
     group('SubscriptionService未初期化時', () {
       test('getSubscriptionInfoV2 → Failure', () async {
-        // 新しいSettingsServiceを作成し、subscriptionServiceを未設定にする
+        // initializeを呼ばないことで_subscriptionDelegateをnullのままにする
         SharedPreferences.setMockInitialValues({});
         serviceLocator.clear();
-        // ISubscriptionServiceを登録しない
-        final uninitService = SettingsService();
-        // initializeを呼ばない（_subscriptionService == null）
+        final uninitService = SettingsService(
+          subscriptionService: mockSubscriptionService,
+        );
+        // initializeを呼ばない（_subscriptionDelegate == null）
 
         final result = await uninitService.getSubscriptionInfoV2();
         expect(result.isFailure, isTrue);

--- a/test/unit/services/settings_service_test.dart
+++ b/test/unit/services/settings_service_test.dart
@@ -10,7 +10,6 @@ import 'package:smart_photo_diary/models/subscription_info_v2.dart';
 import 'package:smart_photo_diary/models/subscription_status.dart';
 import 'package:smart_photo_diary/models/plans/plan.dart';
 import 'package:smart_photo_diary/models/plans/basic_plan.dart';
-import 'package:smart_photo_diary/services/interfaces/subscription_service_interface.dart';
 import 'package:smart_photo_diary/services/settings_service.dart';
 
 import '../../integration/mocks/mock_services.dart';
@@ -30,13 +29,8 @@ void main() {
     mockSubscriptionService = MockSubscriptionServiceInterface();
     when(() => mockSubscriptionService.isInitialized).thenReturn(true);
 
-    // SettingsService.initialize()でISubscriptionServiceをgetAsyncするため登録
-    serviceLocator.registerAsyncFactory<ISubscriptionService>(
-      () async => mockSubscriptionService,
-    );
-
     service = SettingsService();
-    await service.initialize();
+    await service.initialize(subscriptionService: mockSubscriptionService);
   });
 
   tearDown(() {

--- a/test/unit/services/settings_service_v2_test.dart
+++ b/test/unit/services/settings_service_v2_test.dart
@@ -56,7 +56,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       final result = await settingsService.getSubscriptionInfoV2();
 
@@ -81,7 +83,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       final result = await settingsService.getCurrentPlanClass();
 
@@ -110,7 +114,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       final result = await settingsService.getUsageStatisticsWithPlanClass();
 
@@ -147,7 +153,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       final result = await settingsService.getPlanPeriodInfoV2();
 
@@ -170,7 +178,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       final result = await settingsService.getAvailablePlansV2();
 
@@ -201,7 +211,9 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize(subscriptionService: mockSubscriptionService);
+      await settingsService.initialize(
+        subscriptionService: mockSubscriptionService,
+      );
 
       // V2メソッド
       final v2PlanResult = await settingsService.getCurrentPlanClass();

--- a/test/unit/services/settings_service_v2_test.dart
+++ b/test/unit/services/settings_service_v2_test.dart
@@ -55,10 +55,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       final result = await settingsService.getSubscriptionInfoV2();
 
@@ -82,10 +82,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       final result = await settingsService.getCurrentPlanClass();
 
@@ -113,10 +113,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       final result = await settingsService.getUsageStatisticsWithPlanClass();
 
@@ -152,10 +152,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       final result = await settingsService.getPlanPeriodInfoV2();
 
@@ -177,10 +177,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       final result = await settingsService.getAvailablePlansV2();
 
@@ -210,10 +210,10 @@ void main() {
       );
 
       // SettingsServiceを初期化
-      settingsService = SettingsService();
-      await settingsService.initialize(
+      settingsService = SettingsService(
         subscriptionService: mockSubscriptionService,
       );
+      await settingsService.initialize();
 
       // V2メソッド
       final v2PlanResult = await settingsService.getCurrentPlanClass();

--- a/test/unit/services/settings_service_v2_test.dart
+++ b/test/unit/services/settings_service_v2_test.dart
@@ -56,7 +56,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       final result = await settingsService.getSubscriptionInfoV2();
 
@@ -81,7 +81,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       final result = await settingsService.getCurrentPlanClass();
 
@@ -110,7 +110,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       final result = await settingsService.getUsageStatisticsWithPlanClass();
 
@@ -147,7 +147,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       final result = await settingsService.getPlanPeriodInfoV2();
 
@@ -170,7 +170,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       final result = await settingsService.getAvailablePlansV2();
 
@@ -201,7 +201,7 @@ void main() {
 
       // SettingsServiceを初期化
       settingsService = SettingsService();
-      await settingsService.initialize();
+      await settingsService.initialize(subscriptionService: mockSubscriptionService);
 
       // V2メソッド
       final v2PlanResult = await settingsService.getCurrentPlanClass();

--- a/test/unit/utils/performance_monitor_test.dart
+++ b/test/unit/utils/performance_monitor_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:smart_photo_diary/core/service_locator.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
 import 'package:smart_photo_diary/utils/performance_monitor.dart';
 
@@ -11,18 +10,12 @@ void main() {
 
   setUp(() {
     mockLogger = MockLoggingService();
-    if (serviceLocator.isRegistered<ILoggingService>()) {
-      serviceLocator.unregister<ILoggingService>();
-    }
-    serviceLocator.registerSingleton<ILoggingService>(mockLogger);
+    PerformanceMonitor.configure(mockLogger);
     PerformanceMonitor.clearStats();
   });
 
   tearDown(() {
     PerformanceMonitor.clearStats();
-    if (serviceLocator.isRegistered<ILoggingService>()) {
-      serviceLocator.unregister<ILoggingService>();
-    }
   });
 
   group('PerformanceMonitor', () {

--- a/test/widget/diary_detail_screen_test.dart
+++ b/test/widget/diary_detail_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:smart_photo_diary/screens/diary_detail/diary_detail_screen.dart'
 import 'package:smart_photo_diary/services/interfaces/diary_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/diary_crud_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/photo_cache_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/photo_service_interface.dart';
 
 import '../integration/mocks/mock_services.dart';
@@ -18,6 +19,8 @@ import '../test_helpers/mock_platform_channels.dart';
 import '../test_helpers/widget_test_helpers.dart';
 
 class MockIPhotoCacheService extends Mock implements IPhotoCacheService {}
+
+class MockLoggingService extends Mock implements ILoggingService {}
 
 void main() {
   late MockIDiaryService mockDiaryService;
@@ -49,6 +52,8 @@ void main() {
 
     final mockPhotoService = TestServiceSetup.getPhotoService();
     serviceLocator.registerSingleton<IPhotoService>(mockPhotoService);
+
+    serviceLocator.registerSingleton<ILoggingService>(MockLoggingService());
 
     mockPhotoCache = MockIPhotoCacheService();
     when(


### PR DESCRIPTION
## Summary

- Eliminated all direct `serviceLocator` access outside the composition root (`service_registration.dart`)
- Static utility classes (`PerformanceMonitor`, `EnvironmentConfig`, `DynamicPricingUtils`, `DiaryPreviewDialogHelper`) now receive logger via `static configure(ILoggingService)` called at registration time — consistent with existing `ErrorHandler`/`ErrorDisplayService` pattern
- Controllers (`OnboardingController`, `StatisticsController`, `DiaryDetailController`) converted from lazy getter / `late` field to constructor injection with `serviceLocator` fallback only in initializer list
- `SettingsService.initialize()` now accepts `required ISubscriptionService` instead of resolving it via serviceLocator internally
- Widget-level components (`FullscreenPhotoViewer`, `_HeroPhoto`, `FontDebugScreen`) accept optional injected services with serviceLocator fallback for production use

## Test Plan

- [ ] `fvm flutter test` — all tests pass (1772)
- [ ] `fvm flutter analyze` — no issues
- [ ] `fvm dart format .` — no formatting changes
- [ ] Unit tests for `OnboardingController`, `SettingsService`, `SettingsServiceV2` updated to inject mocks directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **改善**
  * アプリケーションの内部アーキテクチャを最適化し、依存関係の管理を改善しました。これによりコードの保守性と信頼性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->