### PR TITLE
refactor: eliminate ServiceRegistration from UI layer

### DIFF
--- a/lib/controllers/diary_detail_controller.dart
+++ b/lib/controllers/diary_detail_controller.dart
@@ -1,7 +1,6 @@
 import 'package:photo_manager/photo_manager.dart';
 
 import '../core/result/result.dart';
-import '../core/service_locator.dart';
 import '../core/service_registration.dart';
 import '../models/diary_entry.dart';
 import '../services/interfaces/diary_crud_service_interface.dart';
@@ -15,9 +14,17 @@ enum DiaryDetailErrorType { notFound, loadFailed, updateFailed, deleteFailed }
 /// DiaryDetailScreen の状態管理・ビジネスロジック
 class DiaryDetailController extends BaseErrorController {
   final ILoggingService _logger;
+  final IDiaryCrudService _diaryCrudService;
+  final IPhotoService _photoService;
 
-  DiaryDetailController({ILoggingService? logger})
-    : _logger = logger ?? serviceLocator.get<ILoggingService>();
+  DiaryDetailController({
+    ILoggingService? logger,
+    IDiaryCrudService? diaryCrudService,
+    IPhotoService? photoService,
+  }) : _logger = logger ?? ServiceRegistration.get<ILoggingService>(),
+       _diaryCrudService =
+           diaryCrudService ?? ServiceRegistration.get<IDiaryCrudService>(),
+       _photoService = photoService ?? ServiceRegistration.get<IPhotoService>();
 
   DiaryEntry? _diaryEntry;
   List<AssetEntity> _photoAssets = [];
@@ -68,10 +75,8 @@ class DiaryDetailController extends BaseErrorController {
       _clearErrorState();
       setLoading(true);
 
-      final diaryService =
-          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return;
-      final result = await diaryService.getDiaryEntry(diaryId);
+      final result = await _diaryCrudService.getDiaryEntry(diaryId);
 
       switch (result) {
         case Success(data: final entry):
@@ -81,10 +86,8 @@ class DiaryDetailController extends BaseErrorController {
             return;
           }
 
-          final photoService =
-              await ServiceRegistration.getAsync<IPhotoService>();
           if (localVersion != _requestVersion) return;
-          final assetsResult = await photoService.getAssetsByIds(
+          final assetsResult = await _photoService.getAssetsByIds(
             entry.photoIds,
           );
 
@@ -126,8 +129,6 @@ class DiaryDetailController extends BaseErrorController {
       setLoading(true);
       _clearErrorState();
 
-      final diaryService =
-          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return false;
 
       final updatedEntry = _diaryEntry!.copyWith(
@@ -135,7 +136,9 @@ class DiaryDetailController extends BaseErrorController {
         content: content,
         updatedAt: DateTime.now(),
       );
-      final updateResult = await diaryService.updateDiaryEntry(updatedEntry);
+      final updateResult = await _diaryCrudService.updateDiaryEntry(
+        updatedEntry,
+      );
       if (localVersion != _requestVersion) return updateResult.isSuccess;
 
       switch (updateResult) {
@@ -165,11 +168,9 @@ class DiaryDetailController extends BaseErrorController {
       setLoading(true);
       _clearErrorState();
 
-      final diaryService =
-          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return false;
-      final deleteResult = await diaryService.deleteDiaryEntry(diaryId);
-      if (localVersion != _requestVersion) return deleteResult.isSuccess;
+      final deleteResult = await _diaryCrudService.deleteDiaryEntry(diaryId);
+      if (localVersion != _requestVersion) return false;
 
       switch (deleteResult) {
         case Success():

--- a/lib/controllers/diary_detail_controller.dart
+++ b/lib/controllers/diary_detail_controller.dart
@@ -14,7 +14,7 @@ enum DiaryDetailErrorType { notFound, loadFailed, updateFailed, deleteFailed }
 /// DiaryDetailScreen の状態管理・ビジネスロジック
 class DiaryDetailController extends BaseErrorController {
   final ILoggingService _logger;
-  final IDiaryCrudService _diaryCrudService;
+  IDiaryCrudService? _diaryCrudService;
   final IPhotoService _photoService;
 
   DiaryDetailController({
@@ -22,8 +22,7 @@ class DiaryDetailController extends BaseErrorController {
     IDiaryCrudService? diaryCrudService,
     IPhotoService? photoService,
   }) : _logger = logger ?? ServiceRegistration.get<ILoggingService>(),
-       _diaryCrudService =
-           diaryCrudService ?? ServiceRegistration.get<IDiaryCrudService>(),
+       _diaryCrudService = diaryCrudService,
        _photoService = photoService ?? ServiceRegistration.get<IPhotoService>();
 
   DiaryEntry? _diaryEntry;
@@ -75,8 +74,10 @@ class DiaryDetailController extends BaseErrorController {
       _clearErrorState();
       setLoading(true);
 
+      _diaryCrudService ??=
+          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return;
-      final result = await _diaryCrudService.getDiaryEntry(diaryId);
+      final result = await _diaryCrudService!.getDiaryEntry(diaryId);
 
       switch (result) {
         case Success(data: final entry):
@@ -129,6 +130,8 @@ class DiaryDetailController extends BaseErrorController {
       setLoading(true);
       _clearErrorState();
 
+      _diaryCrudService ??=
+          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return false;
 
       final updatedEntry = _diaryEntry!.copyWith(
@@ -136,7 +139,7 @@ class DiaryDetailController extends BaseErrorController {
         content: content,
         updatedAt: DateTime.now(),
       );
-      final updateResult = await _diaryCrudService.updateDiaryEntry(
+      final updateResult = await _diaryCrudService!.updateDiaryEntry(
         updatedEntry,
       );
       if (localVersion != _requestVersion) return updateResult.isSuccess;
@@ -168,8 +171,10 @@ class DiaryDetailController extends BaseErrorController {
       setLoading(true);
       _clearErrorState();
 
+      _diaryCrudService ??=
+          await ServiceRegistration.getAsync<IDiaryCrudService>();
       if (localVersion != _requestVersion) return false;
-      final deleteResult = await _diaryCrudService.deleteDiaryEntry(diaryId);
+      final deleteResult = await _diaryCrudService!.deleteDiaryEntry(diaryId);
       if (localVersion != _requestVersion) return false;
 
       switch (deleteResult) {

--- a/lib/controllers/diary_preview_controller.dart
+++ b/lib/controllers/diary_preview_controller.dart
@@ -30,7 +30,7 @@ enum DiaryPreviewLoadingState { idle, initializing, analyzingPhotos, saving }
 /// 日時解決は [PhotoDateResolver] にそれぞれ委譲する。
 class DiaryPreviewController extends BaseErrorController {
   late final ILoggingService _logger;
-  late final Future<IAiService> Function() _getAiService;
+  IAiService? _aiService;
   late final DiaryPreviewGenerationDelegate _generationDelegate;
   late final DiaryPreviewSaveDelegate _saveDelegate;
 
@@ -106,25 +106,20 @@ class DiaryPreviewController extends BaseErrorController {
   DiaryPreviewController({
     required ILoggingService logger,
     required IPhotoService photoService,
-    Future<IAiService> Function()? getAiService,
-    Future<IDiaryCrudService> Function()? getDiaryService,
-    Future<IPromptService> Function()? getPromptService,
+    IAiService? aiService,
+    IDiaryCrudService? diaryCrudService,
+    IPromptService? promptService,
   }) {
     _logger = logger;
-    _getAiService =
-        getAiService ?? () => ServiceRegistration.getAsync<IAiService>();
+    _aiService = aiService;
 
     _generationDelegate = DiaryPreviewGenerationDelegate(
       photoService: photoService,
       logger: _logger,
     );
     _saveDelegate = DiaryPreviewSaveDelegate(
-      getDiaryService:
-          getDiaryService ??
-          () => ServiceRegistration.getAsync<IDiaryCrudService>(),
-      getPromptService:
-          getPromptService ??
-          () => ServiceRegistration.getAsync<IPromptService>(),
+      diaryCrudService: diaryCrudService,
+      promptService: promptService,
       logger: _logger,
     );
   }
@@ -178,7 +173,9 @@ class DiaryPreviewController extends BaseErrorController {
     setLoading(true);
 
     try {
-      final aiService = await _getAiService();
+      if (localVersion != _requestVersion) return;
+
+      _aiService ??= await ServiceRegistration.getAsync<IAiService>();
       if (localVersion != _requestVersion) return;
 
       _photoDateTime = PhotoDateResolver.resolveMedianDateTime(assets);
@@ -186,7 +183,7 @@ class DiaryPreviewController extends BaseErrorController {
       final Result<GenerationOutput> genResult;
       if (assets.length == 1) {
         genResult = await _generationDelegate.generateFromSinglePhoto(
-          aiService: aiService,
+          aiService: _aiService!,
           asset: assets.first,
           photoDateTime: _photoDateTime,
           locale: locale,
@@ -202,7 +199,7 @@ class DiaryPreviewController extends BaseErrorController {
         notifyListeners();
 
         genResult = await _generationDelegate.generateFromMultiplePhotos(
-          aiService: aiService,
+          aiService: _aiService!,
           assets: assets,
           locale: locale,
           prompt: _selectedPrompt?.text,

--- a/lib/controllers/diary_preview_controller.dart
+++ b/lib/controllers/diary_preview_controller.dart
@@ -173,8 +173,6 @@ class DiaryPreviewController extends BaseErrorController {
     setLoading(true);
 
     try {
-      if (localVersion != _requestVersion) return;
-
       _aiService ??= await ServiceRegistration.getAsync<IAiService>();
       if (localVersion != _requestVersion) return;
 

--- a/lib/controllers/diary_preview_save_delegate.dart
+++ b/lib/controllers/diary_preview_save_delegate.dart
@@ -2,22 +2,23 @@ import 'package:photo_manager/photo_manager.dart';
 
 import '../core/result/result.dart';
 import '../core/errors/error_handler.dart';
+import '../core/service_registration.dart';
 import '../services/interfaces/diary_crud_service_interface.dart';
 import '../services/interfaces/logging_service_interface.dart';
 import '../services/interfaces/prompt_service_interface.dart';
 
 /// 日記保存・プロンプト使用記録を担当する内部委譲クラス
 class DiaryPreviewSaveDelegate {
-  final Future<IDiaryCrudService> Function() _getDiaryService;
-  final Future<IPromptService> Function() _getPromptService;
+  IDiaryCrudService? _diaryCrudService;
+  IPromptService? _promptService;
   final ILoggingService _logger;
 
   DiaryPreviewSaveDelegate({
-    required Future<IDiaryCrudService> Function() getDiaryService,
-    required Future<IPromptService> Function() getPromptService,
+    IDiaryCrudService? diaryCrudService,
+    IPromptService? promptService,
     required ILoggingService logger,
-  }) : _getDiaryService = getDiaryService,
-       _getPromptService = getPromptService,
+  }) : _diaryCrudService = diaryCrudService,
+       _promptService = promptService,
        _logger = logger;
 
   /// 日記を保存し、保存された日記IDを返す
@@ -33,9 +34,9 @@ class DiaryPreviewSaveDelegate {
         context: 'DiaryPreviewSaveDelegate',
       );
 
-      final diaryService = await _getDiaryService();
-
-      final saveResult = await diaryService.saveDiaryEntryWithPhotos(
+      _diaryCrudService ??=
+          await ServiceRegistration.getAsync<IDiaryCrudService>();
+      final saveResult = await _diaryCrudService!.saveDiaryEntryWithPhotos(
         date: photoDateTime,
         title: title,
         content: content,
@@ -66,8 +67,10 @@ class DiaryPreviewSaveDelegate {
   /// プロンプト使用履歴を記録（非クリティカル）
   Future<void> recordPromptUsage({required String promptId}) async {
     try {
-      final promptService = await _getPromptService();
-      final result = await promptService.recordPromptUsage(promptId: promptId);
+      _promptService ??= await ServiceRegistration.getAsync<IPromptService>();
+      final result = await _promptService!.recordPromptUsage(
+        promptId: promptId,
+      );
       if (result case Failure(:final exception)) {
         _logger.error(
           'Prompt usage history recording failed',

--- a/lib/controllers/onboarding_controller.dart
+++ b/lib/controllers/onboarding_controller.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../constants/app_constants.dart';
-import '../core/service_locator.dart';
 import '../core/service_registration.dart';
 import '../services/interfaces/logging_service_interface.dart';
 import '../services/interfaces/photo_service_interface.dart';
@@ -16,9 +15,17 @@ class OnboardingController extends ChangeNotifier {
   bool _disposed = false;
 
   final ILoggingService _logger;
+  final ISettingsService _settingsService;
+  final IPhotoService _photoService;
 
-  OnboardingController({ILoggingService? logger})
-    : _logger = logger ?? serviceLocator.get<ILoggingService>();
+  OnboardingController({
+    ILoggingService? logger,
+    ISettingsService? settingsService,
+    IPhotoService? photoService,
+  }) : _logger = logger ?? ServiceRegistration.get<ILoggingService>(),
+       _settingsService =
+           settingsService ?? ServiceRegistration.get<ISettingsService>(),
+       _photoService = photoService ?? ServiceRegistration.get<IPhotoService>();
 
   int get currentPage => _currentPage;
   bool get isProcessing => _isProcessing;
@@ -69,13 +76,10 @@ class OnboardingController extends ChangeNotifier {
     _safeNotifyListeners();
 
     try {
-      final settingsService =
-          await ServiceRegistration.getAsync<ISettingsService>();
-      await settingsService.setFirstLaunchCompleted();
+      await _settingsService.setFirstLaunchCompleted();
 
-      final photoService = ServiceRegistration.get<IPhotoService>();
       // Result is intentionally not checked here — permission is best-effort during onboarding
-      await photoService.requestPermission();
+      await _photoService.requestPermission();
 
       _logger.info('Onboarding completed', context: 'OnboardingScreen');
       return true;

--- a/lib/controllers/settings_controller.dart
+++ b/lib/controllers/settings_controller.dart
@@ -14,6 +14,7 @@ import 'base_error_controller.dart';
 class SettingsController extends BaseErrorController {
   late final ILoggingService _logger;
   ISettingsService? _settingsService;
+  bool _isSettingsLoaded = false;
 
   /// ログサービス（UIウィジェットに渡す用）
   ILoggingService get logger => _logger;
@@ -33,13 +34,17 @@ class SettingsController extends BaseErrorController {
   Locale? get selectedLocale => _selectedLocale;
 
   /// 設定サービス（UI側で直接アクセスが必要な場合用）
-  ISettingsService? get settingsService => _settingsService;
+  ISettingsService get settingsService => _settingsService!;
 
   /// 設定データの読み込みが完了しているか
-  bool get hasSettingsLoaded => _settingsService != null;
+  bool get hasSettingsLoaded => _isSettingsLoaded;
 
-  SettingsController({required ILoggingService logger}) {
+  SettingsController({
+    required ILoggingService logger,
+    ISettingsService? settingsService,
+  }) {
     _logger = logger;
+    _settingsService = settingsService;
   }
 
   /// 設定データを読み込む
@@ -48,18 +53,16 @@ class SettingsController extends BaseErrorController {
     setLoading(true);
 
     try {
-      // settingsService と packageInfo を並列取得
-      final settingsFuture = ServiceRegistration.getAsync<ISettingsService>();
+      _settingsService ??=
+          await ServiceRegistration.getAsync<ISettingsService>();
+      if (localVersion != _requestVersion) return;
+
       final packageFuture = PackageInfo.fromPlatform()
           .then<PackageInfo?>((v) => v)
           .catchError((_) => null);
-      final (settings, packageInfo) = await (
-        settingsFuture,
-        packageFuture,
-      ).wait;
+      final packageInfo = await packageFuture;
       if (localVersion != _requestVersion) return;
 
-      _settingsService = settings;
       _packageInfo = packageInfo;
       _selectedLocale = _settingsService!.locale;
 
@@ -77,6 +80,8 @@ class SettingsController extends BaseErrorController {
           context: 'SettingsController',
         );
       }
+
+      _isSettingsLoaded = true;
     } catch (e) {
       if (localVersion != _requestVersion) return;
       _logger.error(

--- a/lib/controllers/settings_controller.dart
+++ b/lib/controllers/settings_controller.dart
@@ -53,13 +53,13 @@ class SettingsController extends BaseErrorController {
     setLoading(true);
 
     try {
+      final packageFuture = PackageInfo.fromPlatform()
+          .then<PackageInfo?>((v) => v)
+          .catchError((_) => null);
       _settingsService ??=
           await ServiceRegistration.getAsync<ISettingsService>();
       if (localVersion != _requestVersion) return;
 
-      final packageFuture = PackageInfo.fromPlatform()
-          .then<PackageInfo?>((v) => v)
-          .catchError((_) => null);
       final packageInfo = await packageFuture;
       if (localVersion != _requestVersion) return;
 

--- a/lib/screens/diary_preview/diary_preview_dialogs.dart
+++ b/lib/screens/diary_preview/diary_preview_dialogs.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../core/service_registration.dart';
 import '../../localization/localization_extensions.dart';
 import '../../models/plans/basic_plan.dart';
 import '../../services/interfaces/logging_service_interface.dart';
@@ -41,11 +40,11 @@ class DiaryPreviewDialogHelper {
   }
 
   /// Phase 1.7.2.1: 使用量制限エラー専用ダイアログ表示
-  static Future<void> showUsageLimitDialog(BuildContext context) async {
+  static Future<void> showUsageLimitDialog(
+    BuildContext context, {
+    required ISubscriptionService subscriptionService,
+  }) async {
     try {
-      final subscriptionService =
-          await ServiceRegistration.getAsync<ISubscriptionService>();
-
       final planResult = await subscriptionService.getCurrentPlanClass();
       final resetDateResult = await subscriptionService.getNextResetDate();
 

--- a/lib/screens/diary_preview/diary_preview_screen.dart
+++ b/lib/screens/diary_preview/diary_preview_screen.dart
@@ -5,11 +5,11 @@ import '../../constants/app_constants.dart';
 import '../../controllers/diary_preview_controller.dart';
 import '../../core/service_registration.dart';
 import '../../localization/localization_extensions.dart';
-import '../../models/diary_length.dart';
 import '../../models/writing_prompt.dart';
 import '../../services/interfaces/logging_service_interface.dart';
 import '../../services/interfaces/photo_service_interface.dart';
 import '../../services/interfaces/settings_service_interface.dart';
+import '../../services/interfaces/subscription_service_interface.dart';
 import '../../ui/components/animated_button.dart';
 import '../../ui/design_system/app_spacing.dart';
 import '../../ui/animations/list_animations.dart';
@@ -30,11 +30,20 @@ class DiaryPreviewScreen extends StatefulWidget {
   /// 状況補足テキスト（オプション）
   final String? contextText;
 
+  final ILoggingService? logger;
+  final IPhotoService? photoService;
+  final ISettingsService? settingsService;
+  final ISubscriptionService? subscriptionService;
+
   const DiaryPreviewScreen({
     super.key,
     required this.selectedAssets,
     this.selectedPrompt,
     this.contextText,
+    this.logger,
+    this.photoService,
+    this.settingsService,
+    this.subscriptionService,
   });
 
   @override
@@ -43,53 +52,45 @@ class DiaryPreviewScreen extends StatefulWidget {
 
 class _DiaryPreviewScreenState extends State<DiaryPreviewScreen> {
   late final DiaryPreviewController _controller;
+  ISubscriptionService? _subscriptionService;
   late TextEditingController _titleController;
   late TextEditingController _contentController;
 
   @override
   void initState() {
     super.initState();
+    final logger = widget.logger ?? ServiceRegistration.get<ILoggingService>();
+    final photoService =
+        widget.photoService ?? ServiceRegistration.get<IPhotoService>();
+    final settingsService =
+        widget.settingsService ?? ServiceRegistration.get<ISettingsService>();
+    _subscriptionService = widget.subscriptionService;
+    if (_subscriptionService == null) {
+      ServiceRegistration.getAsync<ISubscriptionService>().then((s) {
+        if (mounted) _subscriptionService = s;
+      });
+    }
+
     _controller = DiaryPreviewController(
-      logger: ServiceRegistration.get<ILoggingService>(),
-      photoService: ServiceRegistration.get<IPhotoService>(),
+      logger: logger,
+      photoService: photoService,
     );
     _titleController = TextEditingController();
     _contentController = TextEditingController();
     _controller.addListener(_onControllerChanged);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    final defaultLength = settingsService.diaryLength;
+    _controller.setDiaryLength(defaultLength);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-
-      // Load default diary length from settings (async-safe)
-      var defaultLength = DiaryLength.standard;
-      try {
-        final settingsService =
-            await ServiceRegistration.getAsync<ISettingsService>();
-        defaultLength = settingsService.diaryLength;
-      } catch (e) {
-        // Fall back to standard if settings service is unavailable
-        try {
-          final logger = await ServiceRegistration.getAsync<ILoggingService>();
-          logger.warning(
-            'Failed to load diary length from settings, using standard',
-            context: 'DiaryPreviewScreen.initState',
-            data: e,
-          );
-        } catch (_) {
-          // LoggingService also unavailable — silent fallback acceptable
-        }
-      }
-      _controller.setDiaryLength(defaultLength);
-
-      if (mounted) {
-        _controller.initializeAndGenerate(
-          assets: widget.selectedAssets,
-          prompt: widget.selectedPrompt,
-          contextText: widget.contextText,
-          locale: Localizations.localeOf(context),
-          diaryLength: defaultLength,
-        );
-      }
+      _controller.initializeAndGenerate(
+        assets: widget.selectedAssets,
+        prompt: widget.selectedPrompt,
+        contextText: widget.contextText,
+        locale: Localizations.localeOf(context),
+        diaryLength: defaultLength,
+      );
     });
   }
 
@@ -114,8 +115,13 @@ class _DiaryPreviewScreenState extends State<DiaryPreviewScreen> {
     }
 
     // 使用量制限に到達した場合はダイアログ表示（consumeで1回限り）
-    if (_controller.consumeUsageLimitReached() && mounted) {
-      DiaryPreviewDialogHelper.showUsageLimitDialog(context);
+    if (_controller.consumeUsageLimitReached() &&
+        mounted &&
+        _subscriptionService != null) {
+      DiaryPreviewDialogHelper.showUsageLimitDialog(
+        context,
+        subscriptionService: _subscriptionService!,
+      );
     }
 
     // 自動保存完了後のナビゲーション（consumeで1回限り）

--- a/lib/screens/home/home_data_loader.dart
+++ b/lib/screens/home/home_data_loader.dart
@@ -21,8 +21,7 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
     _self._photoController.setLoading(true);
 
     try {
-      final photoService = ServiceRegistration.get<IPhotoService>();
-      final permissionResult = await photoService.requestPermission();
+      final permissionResult = await _self._photoService.requestPermission();
       final hasPermission = permissionResult.getOrDefault(false);
 
       if (!mounted) return;
@@ -50,7 +49,7 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
         _self._screenshotAssetIds = {};
       }
 
-      final photosResult = await photoService.getPhotosInDateRange(
+      final photosResult = await _self._photoService.getPhotosInDateRange(
         startDate: todayStart.subtract(const Duration(days: _loadDays)),
         endDate: todayStart.add(const Duration(days: 1)),
         limit: _HomeScreenState._photosPerPage,
@@ -65,9 +64,8 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
       if (!mounted) return;
 
       if (photos.isEmpty) {
-        final isLimited = (await photoService.isLimitedAccess()).getOrDefault(
-          false,
-        );
+        final isLimited = (await _self._photoService.isLimitedAccess())
+            .getOrDefault(false);
         if (isLimited) {
           await _self._showLimitedAccessDialog();
         }
@@ -142,14 +140,13 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
     }
 
     try {
-      final photoService = ServiceRegistration.get<IPhotoService>();
       final today = DateTime.now();
       final todayStart = DateTime(today.year, today.month, today.day);
 
       final preloadPages = showLoading ? 1 : AppConstants.timelinePreloadPages;
       final requested = _HomeScreenState._photosPerPage * preloadPages;
 
-      final newPhotosResult = await photoService.getPhotosEfficient(
+      final newPhotosResult = await _self._photoService.getPhotosEfficient(
         startDate: todayStart.subtract(const Duration(days: _loadDays)),
         endDate: todayStart.add(const Duration(days: 1)),
         offset: _self._currentPhotoOffset,
@@ -209,8 +206,7 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
 
   Future<void> _loadUsedPhotoIds() async {
     try {
-      final diaryService = await ServiceRegistration.getAsync<IDiaryService>();
-      final result = await diaryService.getSortedDiaryEntries();
+      final result = await _self._diaryService.getSortedDiaryEntries();
       switch (result) {
         case Success(data: final entries):
           _collectUsedPhotoIds(entries);
@@ -240,8 +236,7 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
 
   Future<void> _subscribeDiaryChanges() async {
     try {
-      final diaryService = await ServiceRegistration.getAsync<IDiaryService>();
-      _self._diarySub = diaryService.changes.listen((change) {
+      _self._diarySub = _self._diaryService.changes.listen((change) {
         switch (change.type) {
           case DiaryChangeType.created:
             _self._photoController.addUsedPhotoIds(change.addedPhotoIds);
@@ -272,9 +267,7 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
   Future<int> _getPlanAccessDays() async {
     int accessDays = 1;
     try {
-      final subscriptionService =
-          await ServiceRegistration.getAsync<ISubscriptionService>();
-      final planResult = await subscriptionService.getCurrentPlanClass();
+      final planResult = await _self._subscriptionService.getCurrentPlanClass();
       if (planResult.isSuccess) {
         final plan = planResult.value;
         accessDays = plan.pastPhotoAccessDays;

--- a/lib/screens/home/home_data_loader.dart
+++ b/lib/screens/home/home_data_loader.dart
@@ -206,7 +206,9 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
 
   Future<void> _loadUsedPhotoIds() async {
     try {
-      final result = await _self._diaryService.getSortedDiaryEntries();
+      _self._diaryService ??=
+          await ServiceRegistration.getAsync<IDiaryService>();
+      final result = await _self._diaryService!.getSortedDiaryEntries();
       switch (result) {
         case Success(data: final entries):
           _collectUsedPhotoIds(entries);
@@ -236,7 +238,9 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
 
   Future<void> _subscribeDiaryChanges() async {
     try {
-      _self._diarySub = _self._diaryService.changes.listen((change) {
+      _self._diaryService ??=
+          await ServiceRegistration.getAsync<IDiaryService>();
+      _self._diarySub = _self._diaryService!.changes.listen((change) {
         switch (change.type) {
           case DiaryChangeType.created:
             _self._photoController.addUsedPhotoIds(change.addedPhotoIds);

--- a/lib/screens/home/home_dialogs.dart
+++ b/lib/screens/home/home_dialogs.dart
@@ -97,9 +97,8 @@ mixin _HomeDialogsMixin on State<HomeScreen> {
               isPrimary: true,
               onPressed: () async {
                 Navigator.of(context).pop();
-                final photoService = ServiceRegistration.get<IPhotoService>();
                 // Result is intentionally not checked here — fire and forget
-                await photoService.presentLimitedLibraryPicker();
+                await _self._photoService.presentLimitedLibraryPicker();
                 _self._loadTodayPhotos();
               },
             ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -40,12 +40,18 @@ class HomeScreen extends StatefulWidget {
   final Function(ThemeMode)? onThemeChanged;
   final ILoggingService? logger;
   final ISettingsService? settingsService;
+  final IPhotoService? photoService;
+  final IDiaryService? diaryService;
+  final ISubscriptionService? subscriptionService;
 
   const HomeScreen({
     super.key,
     this.onThemeChanged,
     this.logger,
     this.settingsService,
+    this.photoService,
+    this.diaryService,
+    this.subscriptionService,
   });
 
   @override
@@ -56,6 +62,9 @@ class _HomeScreenState extends State<HomeScreen>
     with WidgetsBindingObserver, _HomeDialogsMixin, _HomeDataLoaderMixin {
   // サービス
   late final ILoggingService _logger;
+  late final IPhotoService _photoService;
+  late final IDiaryService _diaryService;
+  late final ISubscriptionService _subscriptionService;
 
   // タブナビゲーション・画面キー管理コントローラー
   late final HomeController _homeController;
@@ -93,6 +102,13 @@ class _HomeScreenState extends State<HomeScreen>
     _logger = widget.logger ?? serviceLocator.get<ILoggingService>();
     _settingsService =
         widget.settingsService ?? serviceLocator.get<ISettingsService>();
+    _photoService =
+        widget.photoService ?? ServiceRegistration.get<IPhotoService>();
+    _diaryService =
+        widget.diaryService ?? ServiceRegistration.get<IDiaryService>();
+    _subscriptionService =
+        widget.subscriptionService ??
+        ServiceRegistration.get<ISubscriptionService>();
     _photoTypeFilter = _settingsService.photoTypeFilter;
     _settingsService.photoTypeFilterNotifier.addListener(
       _onPhotoTypeFilterChanged,
@@ -171,8 +187,7 @@ class _HomeScreenState extends State<HomeScreen>
   /// 写真IDから日記詳細画面に遷移
   Future<void> _navigateToDiaryDetailByPhotoId(String photoId) async {
     try {
-      final diaryService = await ServiceRegistration.getAsync<IDiaryService>();
-      final result = await diaryService.getDiaryEntryByPhotoId(photoId);
+      final result = await _diaryService.getDiaryEntryByPhotoId(photoId);
 
       switch (result) {
         case Success(data: final diaryEntry):
@@ -215,15 +230,13 @@ class _HomeScreenState extends State<HomeScreen>
   // カメラ撮影処理
   Future<void> _capturePhoto() async {
     try {
-      final photoService = ServiceRegistration.get<IPhotoService>();
-
       _logger.info(
         'Starting camera capture (from FAB)',
         context: 'HomeScreen._capturePhoto',
       );
 
       // カメラで撮影（権限チェックはcapturePhoto内で実行）
-      final captureResult = await photoService.capturePhoto();
+      final captureResult = await _photoService.capturePhoto();
 
       if (captureResult.isFailure) {
         _logger.error(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -63,7 +63,7 @@ class _HomeScreenState extends State<HomeScreen>
   // サービス
   late final ILoggingService _logger;
   late final IPhotoService _photoService;
-  late final IDiaryService _diaryService;
+  IDiaryService? _diaryService;
   late final ISubscriptionService _subscriptionService;
 
   // タブナビゲーション・画面キー管理コントローラー
@@ -104,8 +104,7 @@ class _HomeScreenState extends State<HomeScreen>
         widget.settingsService ?? serviceLocator.get<ISettingsService>();
     _photoService =
         widget.photoService ?? ServiceRegistration.get<IPhotoService>();
-    _diaryService =
-        widget.diaryService ?? ServiceRegistration.get<IDiaryService>();
+    _diaryService = widget.diaryService;
     _subscriptionService =
         widget.subscriptionService ??
         ServiceRegistration.get<ISubscriptionService>();
@@ -187,7 +186,8 @@ class _HomeScreenState extends State<HomeScreen>
   /// 写真IDから日記詳細画面に遷移
   Future<void> _navigateToDiaryDetailByPhotoId(String photoId) async {
     try {
-      final result = await _diaryService.getDiaryEntryByPhotoId(photoId);
+      _diaryService ??= await ServiceRegistration.getAsync<IDiaryService>();
+      final result = await _diaryService!.getDiaryEntryByPhotoId(photoId);
 
       switch (result) {
         case Success(data: final diaryEntry):

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,8 +17,14 @@ import '../widgets/settings/settings_loading_view.dart';
 class SettingsScreen extends StatefulWidget {
   final Function(ThemeMode)? onThemeChanged;
   final ScrollSignal? scrollSignal;
+  final ILoggingService? logger;
 
-  const SettingsScreen({super.key, this.onThemeChanged, this.scrollSignal});
+  const SettingsScreen({
+    super.key,
+    this.onThemeChanged,
+    this.scrollSignal,
+    this.logger,
+  });
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -32,7 +38,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void initState() {
     super.initState();
     _controller = SettingsController(
-      logger: ServiceRegistration.get<ILoggingService>(),
+      logger: widget.logger ?? ServiceRegistration.get<ILoggingService>(),
     );
     _scrollController = ScrollController();
     widget.scrollSignal?.addListener(_onScrollToTop);
@@ -76,7 +82,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     const SettingsLoadingView()
                   else if (_controller.hasSettingsLoaded)
                     SettingsContentBody(
-                      settingsService: _controller.settingsService!,
+                      settingsService: _controller.settingsService,
                       logger: _controller.logger,
                       selectedLocale: _controller.selectedLocale,
                       subscriptionInfo: _controller.subscriptionInfo,

--- a/lib/widgets/home_content_widget.dart
+++ b/lib/widgets/home_content_widget.dart
@@ -22,6 +22,7 @@ class HomeContentWidget extends StatefulWidget {
   final Function(String) onDiaryTap;
   final Future<void> Function()? onRefresh;
   final ScrollSignal? scrollSignal;
+  final ISubscriptionService? subscriptionService;
 
   const HomeContentWidget({
     super.key,
@@ -30,6 +31,7 @@ class HomeContentWidget extends StatefulWidget {
     required this.onDiaryTap,
     this.onRefresh,
     this.scrollSignal,
+    this.subscriptionService,
   });
 
   @override
@@ -37,19 +39,22 @@ class HomeContentWidget extends StatefulWidget {
 }
 
 class _HomeContentWidgetState extends State<HomeContentWidget> {
+  late final ISubscriptionService _subscriptionService;
   int? _remainingGenerations;
   Plan? _cachedPlan;
 
   @override
   void initState() {
     super.initState();
+    _subscriptionService =
+        widget.subscriptionService ??
+        ServiceRegistration.get<ISubscriptionService>();
     _loadUsageSummary();
   }
 
   Future<void> _loadUsageSummary() async {
-    final service = await ServiceRegistration.getAsync<ISubscriptionService>();
-    final remainingFuture = service.getRemainingGenerations();
-    final planFuture = service.getCurrentPlanClass();
+    final remainingFuture = _subscriptionService.getRemainingGenerations();
+    final planFuture = _subscriptionService.getCurrentPlanClass();
     final remainingResult = await remainingFuture;
     final planResult = await planFuture;
     if (mounted) {
@@ -187,13 +192,10 @@ class _HomeContentWidgetState extends State<HomeContentWidget> {
 
   Future<void> _showUsageStatus(BuildContext context) async {
     try {
-      final subscriptionService =
-          await ServiceRegistration.getAsync<ISubscriptionService>();
-
       // 常に最新のプラン情報を取得し、プラン変更が即座にダイアログに反映されるようにする
-      final statusFuture = subscriptionService.getCurrentStatus();
-      final resetDateFuture = subscriptionService.getNextResetDate();
-      final planFuture = subscriptionService.getCurrentPlanClass();
+      final statusFuture = _subscriptionService.getCurrentStatus();
+      final resetDateFuture = _subscriptionService.getNextResetDate();
+      final planFuture = _subscriptionService.getCurrentPlanClass();
 
       final statusResult = await statusFuture;
       final planResult = await planFuture;

--- a/lib/widgets/past_photo_calendar_widget.dart
+++ b/lib/widgets/past_photo_calendar_widget.dart
@@ -5,14 +5,13 @@ import '../constants/app_constants.dart';
 import '../models/plans/plan.dart';
 import '../services/interfaces/photo_service_interface.dart';
 import '../services/interfaces/diary_query_service_interface.dart';
-import '../core/service_registration.dart';
 import '../core/result/result.dart';
+import '../core/service_registration.dart';
 import '../ui/design_system/app_spacing.dart';
 import '../ui/design_system/app_typography.dart';
 import '../ui/components/custom_card.dart';
 import '../ui/animations/list_animations.dart';
 import '../services/interfaces/logging_service_interface.dart';
-import '../core/service_locator.dart';
 import '../core/errors/error_handler.dart';
 import '../localization/localization_extensions.dart';
 import 'past_photo_calendar_builders.dart';
@@ -25,6 +24,8 @@ class PastPhotoCalendarWidget extends StatefulWidget {
   final Set<String> usedPhotoIds;
   final Function()? onSelectionCleared;
   final ILoggingService? logger;
+  final IPhotoService? photoService;
+  final IDiaryQueryService? diaryQueryService;
 
   const PastPhotoCalendarWidget({
     super.key,
@@ -34,6 +35,8 @@ class PastPhotoCalendarWidget extends StatefulWidget {
     required this.usedPhotoIds,
     this.onSelectionCleared,
     this.logger,
+    this.photoService,
+    this.diaryQueryService,
   });
 
   @override
@@ -43,6 +46,8 @@ class PastPhotoCalendarWidget extends StatefulWidget {
 
 class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
   late final ILoggingService _logger;
+  late final IPhotoService _photoService;
+  late final IDiaryQueryService _diaryQueryService;
   late DateTime _focusedDay;
   DateTime? _selectedDay;
   final Map<DateTime, List<AssetEntity>> _photosByDate = {};
@@ -66,7 +71,12 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
   @override
   void initState() {
     super.initState();
-    _logger = widget.logger ?? serviceLocator.get<ILoggingService>();
+    _logger = widget.logger ?? ServiceRegistration.get<ILoggingService>();
+    _photoService =
+        widget.photoService ?? ServiceRegistration.get<IPhotoService>();
+    _diaryQueryService =
+        widget.diaryQueryService ??
+        ServiceRegistration.get<IDiaryQueryService>();
     // focusedDayを昨日に設定（今日は除外されるため）
     final now = DateTime.now();
     _focusedDay = DateTime(
@@ -92,8 +102,6 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
     setState(() => _isLoading = true);
 
     try {
-      final photoService = ServiceRegistration.get<IPhotoService>();
-
       // 月の開始と終了を計算
       final startOfMonth = DateTime(month.year, month.month, 1);
       final endOfMonth = DateTime(month.year, month.month + 1, 0, 23, 59, 59);
@@ -108,7 +116,7 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
           : endOfMonth;
 
       // 月単位で写真を取得
-      final photosResult = await photoService.getPhotosInDateRange(
+      final photosResult = await _photoService.getPhotosInDateRange(
         startDate: startOfMonth,
         endDate: adjustedEnd.add(const Duration(days: 1)),
         limit: 1000, // 月単位の写真数上限
@@ -151,8 +159,6 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
   /// 特定日の写真を読み込み
   Future<void> _loadPhotosForDate(DateTime date) async {
     try {
-      final photoService = ServiceRegistration.get<IPhotoService>();
-
       final startOfDay = DateTime(date.year, date.month, date.day);
       final endOfDay = DateTime(
         date.year,
@@ -164,7 +170,7 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
         999,
       );
 
-      final photosResult = await photoService.getPhotosInDateRange(
+      final photosResult = await _photoService.getPhotosInDateRange(
         startDate: startOfDay,
         endDate: endOfDay,
         limit: 200, // 1日あたりの写真数上限
@@ -234,9 +240,7 @@ class _PastPhotoCalendarWidgetState extends State<PastPhotoCalendarWidget> {
   /// 日記が存在する日付を読み込み
   Future<void> _loadDiaryDates() async {
     try {
-      final diaryService =
-          await ServiceRegistration.getAsync<IDiaryQueryService>();
-      final result = await diaryService.getSortedDiaryEntries();
+      final result = await _diaryQueryService.getSortedDiaryEntries();
       if (!mounted) return;
 
       switch (result) {

--- a/lib/widgets/prompt_list_item.dart
+++ b/lib/widgets/prompt_list_item.dart
@@ -24,67 +24,72 @@ class PromptListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    return Ink(
+    final borderRadius = BorderRadius.circular(14);
+    return DecoratedBox(
       decoration: BoxDecoration(
         color: isSelected ? AppColors.selectedBg : Colors.transparent,
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: borderRadius,
         border: Border.all(
           color: isSelected ? AppColors.accent : Colors.transparent,
         ),
       ),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(14),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  ModernChip.tonedTag(
-                    PromptCategoryUtils.getCategoryDisplayName(
-                      prompt.category,
-                      locale: Localizations.localeOf(context),
+      child: Material(
+        type: MaterialType.transparency,
+        borderRadius: borderRadius,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: borderRadius,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    ModernChip.tonedTag(
+                      PromptCategoryUtils.getCategoryDisplayName(
+                        prompt.category,
+                        locale: Localizations.localeOf(context),
+                      ),
+                      index: prompt.category.index,
                     ),
-                    index: prompt.category.index,
-                  ),
-                  if (!isPremium && prompt.isPremiumOnly) ...[
-                    const SizedBox(width: AppSpacing.xs),
-                    const _PremiumBadge(),
+                    if (!isPremium && prompt.isPremiumOnly) ...[
+                      const SizedBox(width: AppSpacing.xs),
+                      const _PremiumBadge(),
+                    ],
+                    const Spacer(),
+                    if (isSelected)
+                      const Icon(
+                        Icons.check_circle,
+                        color: AppColors.accent,
+                        size: 20,
+                      ),
                   ],
-                  const Spacer(),
-                  if (isSelected)
-                    const Icon(
-                      Icons.check_circle,
-                      color: AppColors.accent,
-                      size: 20,
-                    ),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Text(
-                prompt.text,
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
-                  letterSpacing: -0.1,
-                  height: 1.4,
-                  color: colorScheme.onSurface,
                 ),
-              ),
-              if (prompt.description != null) ...[
-                const SizedBox(height: AppSpacing.xs),
+                const SizedBox(height: AppSpacing.sm),
                 Text(
-                  prompt.description!,
+                  prompt.text,
                   style: TextStyle(
-                    fontSize: 12.5,
-                    height: 1.5,
-                    color: colorScheme.onSurfaceVariant,
+                    fontSize: 15,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                    letterSpacing: -0.1,
+                    height: 1.4,
+                    color: colorScheme.onSurface,
                   ),
                 ),
+                if (prompt.description != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    prompt.description!,
+                    style: TextStyle(
+                      fontSize: 12.5,
+                      height: 1.5,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/prompt_selection_modal.dart
+++ b/lib/widgets/prompt_selection_modal.dart
@@ -5,7 +5,6 @@ import '../models/writing_prompt.dart';
 import '../services/interfaces/prompt_service_interface.dart';
 import '../services/interfaces/subscription_service_interface.dart';
 import '../core/service_registration.dart';
-import '../core/service_locator.dart';
 import '../services/interfaces/logging_service_interface.dart';
 import '../ui/design_system/app_colors.dart';
 import '../ui/design_system/app_spacing.dart';
@@ -59,7 +58,12 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
   @override
   void initState() {
     super.initState();
-    _logger = widget.logger ?? serviceLocator.get<ILoggingService>();
+    _logger = widget.logger ?? ServiceRegistration.get<ILoggingService>();
+    _promptService =
+        widget.promptService ?? ServiceRegistration.get<IPromptService>();
+    _subscriptionService =
+        widget.subscriptionService ??
+        ServiceRegistration.get<ISubscriptionService>();
     _contextController = TextEditingController();
     _contextAnimationController = AnimationController(
       duration: AppConstants.quickAnimationDuration,
@@ -92,17 +96,6 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
 
   Future<void> _initializeServices() async {
     try {
-      final services = await Future.wait([
-        widget.promptService != null
-            ? Future.value(widget.promptService!)
-            : ServiceRegistration.getAsync<IPromptService>(),
-        widget.subscriptionService != null
-            ? Future.value(widget.subscriptionService!)
-            : ServiceRegistration.getAsync<ISubscriptionService>(),
-      ]);
-      _promptService = services[0] as IPromptService;
-      _subscriptionService = services[1] as ISubscriptionService;
-
       final accessResult = await _subscriptionService
           .canAccessPremiumFeatures();
       if (accessResult.isSuccess) {

--- a/lib/widgets/prompt_selection_modal.dart
+++ b/lib/widgets/prompt_selection_modal.dart
@@ -455,7 +455,7 @@ class _QuickOptionCell extends StatelessWidget {
         : AppColors.cardBg;
     final glyphBgColor = colorScheme.surfaceContainerHighest;
 
-    return Ink(
+    return DecoratedBox(
       decoration: BoxDecoration(
         color: isSelected ? AppColors.selectedBg : cardBgColor,
         borderRadius: AppSpacing.cardRadiusLarge,
@@ -465,66 +465,70 @@ class _QuickOptionCell extends StatelessWidget {
               : (isDark ? AppColors.outlineDark : AppColors.divider),
         ),
       ),
-      child: InkWell(
+      child: Material(
+        type: MaterialType.transparency,
         borderRadius: AppSpacing.cardRadiusLarge,
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    width: 28,
-                    height: 28,
-                    decoration: BoxDecoration(
-                      color: isSelected ? AppColors.accent : glyphBgColor,
-                      borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: AppSpacing.cardRadiusLarge,
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      width: 28,
+                      height: 28,
+                      decoration: BoxDecoration(
+                        color: isSelected ? AppColors.accent : glyphBgColor,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(
+                        icon,
+                        size: 16,
+                        color: isSelected
+                            ? Colors.white
+                            : colorScheme.onSurfaceVariant,
+                      ),
                     ),
-                    child: Icon(
-                      icon,
-                      size: 16,
-                      color: isSelected
-                          ? Colors.white
-                          : colorScheme.onSurfaceVariant,
-                    ),
+                    const Spacer(),
+                    if (isSelected)
+                      const Icon(
+                        Icons.check_circle,
+                        size: 18,
+                        color: AppColors.accent,
+                      ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.1,
+                    height: 1.2,
+                    color: colorScheme.onSurface,
                   ),
-                  const Spacer(),
-                  if (isSelected)
-                    const Icon(
-                      Icons.check_circle,
-                      size: 18,
-                      color: AppColors.accent,
-                    ),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Text(
-                title,
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: -0.1,
-                  height: 1.2,
-                  color: colorScheme.onSurface,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: AppSpacing.xs),
-              Text(
-                desc,
-                style: TextStyle(
-                  fontSize: 11.5,
-                  fontWeight: FontWeight.w400,
-                  height: 1.45,
-                  color: colorScheme.onSurfaceVariant,
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  desc,
+                  style: TextStyle(
+                    fontSize: 11.5,
+                    fontWeight: FontWeight.w400,
+                    height: 1.45,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/prompt_selection_modal.dart
+++ b/lib/widgets/prompt_selection_modal.dart
@@ -40,7 +40,7 @@ class PromptSelectionModal extends StatefulWidget {
 class _PromptSelectionModalState extends State<PromptSelectionModal>
     with SingleTickerProviderStateMixin {
   late final ILoggingService _logger;
-  late final IPromptService _promptService;
+  IPromptService? _promptService;
   late final ISubscriptionService _subscriptionService;
 
   bool _isLoading = true;
@@ -59,8 +59,7 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
   void initState() {
     super.initState();
     _logger = widget.logger ?? ServiceRegistration.get<ILoggingService>();
-    _promptService =
-        widget.promptService ?? ServiceRegistration.get<IPromptService>();
+    _promptService = widget.promptService;
     _subscriptionService =
         widget.subscriptionService ??
         ServiceRegistration.get<ISubscriptionService>();
@@ -96,6 +95,7 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
 
   Future<void> _initializeServices() async {
     try {
+      _promptService ??= await ServiceRegistration.getAsync<IPromptService>();
       final accessResult = await _subscriptionService
           .canAccessPremiumFeatures();
       if (accessResult.isSuccess) {
@@ -105,7 +105,7 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
       if (!mounted) return;
 
       final locale = Localizations.localeOf(context);
-      _availablePrompts = _promptService.getPromptsForPlan(
+      _availablePrompts = _promptService!.getPromptsForPlan(
         isPremium: _isPremium,
         locale: locale,
       );
@@ -166,7 +166,7 @@ class _PromptSelectionModalState extends State<PromptSelectionModal>
         onPressed: () {
           final contextText = _getContextText();
           if (_isRandomSelected) {
-            final randomPrompt = _promptService.getRandomPrompt(
+            final randomPrompt = _promptService!.getRandomPrompt(
               isPremium: _isPremium,
               locale: Localizations.localeOf(context),
             );

--- a/lib/widgets/settings/storage_settings_section.dart
+++ b/lib/widgets/settings/storage_settings_section.dart
@@ -11,10 +11,32 @@ import 'storage_import_result_dialog.dart';
 /// Storage and backup-related settings section.
 ///
 /// Displays backup and restore actions.
-class StorageSettingsSection extends StatelessWidget {
+class StorageSettingsSection extends StatefulWidget {
   final VoidCallback onReloadSettings;
+  final IStorageService? storageService;
+  final ILoggingService? logger;
 
-  const StorageSettingsSection({super.key, required this.onReloadSettings});
+  const StorageSettingsSection({
+    super.key,
+    required this.onReloadSettings,
+    this.storageService,
+    this.logger,
+  });
+
+  @override
+  State<StorageSettingsSection> createState() => _StorageSettingsSectionState();
+}
+
+class _StorageSettingsSectionState extends State<StorageSettingsSection> {
+  IStorageService? _storageService;
+  late final ILoggingService _logger;
+
+  @override
+  void initState() {
+    super.initState();
+    _storageService = widget.storageService;
+    _logger = widget.logger ?? ServiceRegistration.get<ILoggingService>();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,9 +73,8 @@ class StorageSettingsSection extends StatelessWidget {
         context.l10n.settingsBackupInProgress,
       );
 
-      final storageService =
-          await ServiceRegistration.getAsync<IStorageService>();
-      final exportResult = await storageService.exportDataResult();
+      _storageService ??= await ServiceRegistration.getAsync<IStorageService>();
+      final exportResult = await _storageService!.exportDataResult();
 
       if (!context.mounted) return;
       Navigator.pop(context);
@@ -77,7 +98,7 @@ class StorageSettingsSection extends StatelessWidget {
         );
       }
     } catch (e) {
-      ServiceRegistration.get<ILoggingService>().error(
+      _logger.error(
         'Data export failed',
         context: 'StorageSettingsSection._exportData',
         error: e,
@@ -98,9 +119,8 @@ class StorageSettingsSection extends StatelessWidget {
         context.l10n.settingsRestoreInProgress,
       );
 
-      final storageService =
-          await ServiceRegistration.getAsync<IStorageService>();
-      final result = await storageService.importData();
+      _storageService ??= await ServiceRegistration.getAsync<IStorageService>();
+      final result = await _storageService!.importData();
 
       if (!context.mounted) return;
       Navigator.pop(context);
@@ -108,7 +128,7 @@ class StorageSettingsSection extends StatelessWidget {
       result.fold(
         (importResult) {
           if (importResult == null) return;
-          onReloadSettings();
+          widget.onReloadSettings();
           StorageImportResultDialog.show(context, importResult);
         },
         (error) {
@@ -119,7 +139,7 @@ class StorageSettingsSection extends StatelessWidget {
         },
       );
     } catch (e) {
-      ServiceRegistration.get<ILoggingService>().error(
+      _logger.error(
         'Data restore failed',
         context: 'StorageSettingsSection._restoreData',
         error: e,

--- a/lib/widgets/timeline_fab_integration.dart
+++ b/lib/widgets/timeline_fab_integration.dart
@@ -24,12 +24,15 @@ class TimelineFABIntegration extends StatelessWidget {
   /// 外部から先頭へスクロールさせるためのシグナル
   final ScrollSignal? scrollSignal;
 
-  const TimelineFABIntegration({
+  final ILoggingService _logger;
+
+  TimelineFABIntegration({
     super.key,
     required this.controller,
     this.callbacks = const TimelineCallbacks(),
     this.scrollSignal,
-  });
+    ILoggingService? logger,
+  }) : _logger = logger ?? ServiceRegistration.get<ILoggingService>();
 
   @override
   Widget build(BuildContext context) {
@@ -142,19 +145,17 @@ class TimelineFABIntegration extends StatelessWidget {
   }
 
   Future<void> _onCreateDiaryPressed(BuildContext context) async {
-    final logger = ServiceRegistration.get<ILoggingService>();
-
     try {
       final selectedPhotos = controller.selectedPhotos;
 
-      logger.info(
+      _logger.info(
         'Starting diary creation (from smart FAB)',
         context: 'TimelineFABIntegration._onCreateDiaryPressed',
         data: 'Selected photos: ${selectedPhotos.length}',
       );
 
       if (selectedPhotos.isEmpty) {
-        logger.warning(
+        _logger.warning(
           'Diary creation: no photos selected',
           context: 'TimelineFABIntegration._onCreateDiaryPressed',
         );
@@ -171,7 +172,7 @@ class TimelineFABIntegration extends StatelessWidget {
               context,
               selectedPhotos,
               prompt,
-              logger: logger,
+              logger: _logger,
               contextText: contextText,
             );
           },
@@ -181,14 +182,14 @@ class TimelineFABIntegration extends StatelessWidget {
               context,
               selectedPhotos,
               null,
-              logger: logger,
+              logger: _logger,
               contextText: contextText,
             );
           },
         ),
       );
     } catch (e) {
-      logger.error(
+      _logger.error(
         'Error during diary creation process',
         context: 'TimelineFABIntegration._onCreateDiaryPressed',
         error: e,

--- a/test/integration/smoke/diary_save_view_smoke_test.dart
+++ b/test/integration/smoke/diary_save_view_smoke_test.dart
@@ -39,8 +39,8 @@ void main() {
       return DiaryPreviewController(
         logger: logger,
         photoService: IntegrationTestHelpers.mockPhotoService,
-        getAiService: () async => effectiveAiMock,
-        getDiaryService: () async => mockDiaryService,
+        aiService: effectiveAiMock,
+        diaryCrudService: mockDiaryService,
       );
     }
 

--- a/test/integration/smoke/photo_to_diary_smoke_test.dart
+++ b/test/integration/smoke/photo_to_diary_smoke_test.dart
@@ -47,8 +47,8 @@ void main() {
       return DiaryPreviewController(
         logger: logger,
         photoService: IntegrationTestHelpers.mockPhotoService,
-        getAiService: () async => effectiveAiMock,
-        getDiaryService: () async => mockDiaryService,
+        aiService: effectiveAiMock,
+        diaryCrudService: mockDiaryService,
       );
     }
 

--- a/test/integration/smoke/settings_flow_smoke_test.dart
+++ b/test/integration/smoke/settings_flow_smoke_test.dart
@@ -46,7 +46,7 @@ void main() {
 
       await controller.loadSettings();
 
-      expect(controller.settingsService?.themeMode, equals(ThemeMode.system));
+      expect(controller.settingsService.themeMode, equals(ThemeMode.system));
     });
 
     test('loadSettings 後に localeNotifier が日本語を示す', () async {
@@ -55,9 +55,9 @@ void main() {
 
       await controller.loadSettings();
 
-      expect(controller.settingsService?.localeNotifier, isNotNull);
+      expect(controller.settingsService.localeNotifier, isNotNull);
       expect(
-        controller.settingsService?.localeNotifier.value,
+        controller.settingsService.localeNotifier.value,
         equals(const Locale('ja')),
       );
     });

--- a/test/unit/controllers/diary_preview_controller_test.dart
+++ b/test/unit/controllers/diary_preview_controller_test.dart
@@ -4,10 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:smart_photo_diary/controllers/diary_preview_controller.dart';
-import 'package:smart_photo_diary/core/service_locator.dart';
 import 'package:smart_photo_diary/services/interfaces/ai_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/diary_crud_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/photo_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/prompt_service_interface.dart';
 import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
 
@@ -17,32 +18,34 @@ class MockAiService extends Mock implements IAiService {}
 
 class MockPhotoService extends Mock implements IPhotoService {}
 
+class MockDiaryCrudService extends Mock implements IDiaryCrudService {}
+
+class MockPromptService extends Mock implements IPromptService {}
+
 class MockAssetEntity extends Mock implements AssetEntity {}
 
 void main() {
   late MockLoggingService mockLogger;
   late MockAiService mockAiService;
   late MockPhotoService mockPhotoService;
+  late MockDiaryCrudService mockDiaryCrudService;
+  late MockPromptService mockPromptService;
 
   setUp(() {
-    ServiceLocator().clear();
     mockLogger = MockLoggingService();
     mockAiService = MockAiService();
     mockPhotoService = MockPhotoService();
-
-    ServiceLocator().registerSingleton<ILoggingService>(mockLogger);
-    ServiceLocator().registerSingleton<IAiService>(mockAiService);
-    ServiceLocator().registerSingleton<IPhotoService>(mockPhotoService);
-  });
-
-  tearDown(() {
-    ServiceLocator().clear();
+    mockDiaryCrudService = MockDiaryCrudService();
+    mockPromptService = MockPromptService();
   });
 
   DiaryPreviewController createController() {
     return DiaryPreviewController(
       logger: mockLogger,
       photoService: mockPhotoService,
+      aiService: mockAiService,
+      diaryCrudService: mockDiaryCrudService,
+      promptService: mockPromptService,
     );
   }
 

--- a/test/unit/controllers/onboarding_controller_test.dart
+++ b/test/unit/controllers/onboarding_controller_test.dart
@@ -2,15 +2,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:smart_photo_diary/controllers/onboarding_controller.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/photo_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/settings_service_interface.dart';
 
 class _MockLogger extends Mock implements ILoggingService {}
+
+class _MockSettingsService extends Mock implements ISettingsService {}
+
+class _MockPhotoService extends Mock implements IPhotoService {}
 
 void main() {
   late OnboardingController controller;
   bool manuallyDisposed = false;
 
   setUp(() {
-    controller = OnboardingController(logger: _MockLogger());
+    controller = OnboardingController(
+      logger: _MockLogger(),
+      settingsService: _MockSettingsService(),
+      photoService: _MockPhotoService(),
+    );
     manuallyDisposed = false;
   });
 

--- a/test/widget/locale_switch_widget_test.dart
+++ b/test/widget/locale_switch_widget_test.dart
@@ -4,11 +4,14 @@ import 'package:mocktail/mocktail.dart';
 import 'package:smart_photo_diary/core/service_locator.dart';
 import 'package:smart_photo_diary/main.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/photo_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/settings_service_interface.dart';
 
 class _MockSettingsService extends Mock implements ISettingsService {}
 
 class _MockLoggingService extends Mock implements ILoggingService {}
+
+class _MockPhotoService extends Mock implements IPhotoService {}
 
 void main() {
   setUp(() {
@@ -34,6 +37,7 @@ void main() {
 
       serviceLocator.registerSingleton<ILoggingService>(loggingService);
       serviceLocator.registerSingleton<ISettingsService>(settingsService);
+      serviceLocator.registerSingleton<IPhotoService>(_MockPhotoService());
 
       addTearDown(localeNotifier.dispose);
 


### PR DESCRIPTION
## Summary
- Remove `ServiceRegistration.get()` calls from UI layer method bodies (controllers/widgets), resolving services at composition root or via async lazy resolution
- Switch `IDiaryService`, `IDiaryCrudService`, and `IPromptService` to async lazy resolution to prevent runtime crashes from premature sync access
- Simplify settings load by removing redundant version check and restoring parallel fetch
- Fix selected prompt borders not rendering in the prompt modal — replace `Ink` with `DecoratedBox + Material(transparent) + InkWell` so border draws reliably inside `ListView`

## Test Plan
- [ ] `fvm flutter analyze` shows no issues
- [ ] `fvm flutter test` — all tests pass
- [ ] HomeScreen loads without crashing (verifies async lazy resolution fix)
- [ ] Settings screen loads correctly with subscription state
- [ ] Prompt modal: tap each option (no prompt / random / a specific prompt) and confirm the accent-colored border appears on the selected item in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 依存性注入パターンを最適化し、アプリケーションの内部アーキテクチャを改善しました
  * サービス提供メカニズムを刷新し、保守性と拡張性を向上させました

* **テスト**
  * テストスイートを最新のアーキテクチャパターンに対応させました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->