### PR TITLE
fix: show overflow badge when diary card tags exceed display limit

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -126,6 +126,7 @@ class AppConstants {
   static const int timelinePreloadPages = 2; // 先読み時はページ数×この倍率で取得
 
   // 日記一覧（Diary）関連
+  static const int tagCardDisplayLimit = 3; // カード上に表示するタグ件数上限
   static const int diaryPageSize = 20; // 一度に取得する日記件数
   static const double diaryListLoadMoreThresholdRatio = 0.85; // 末尾手前での追加読込閾値
   static const int diaryListInitialShimmerCount = 6; // 初期ローディングのプレースホルダー件数

--- a/lib/widgets/diary_card_widget.dart
+++ b/lib/widgets/diary_card_widget.dart
@@ -283,13 +283,14 @@ class _DiaryCardWidgetState extends State<DiaryCardWidget> {
   }
 
   Widget _buildTagChips(List<String> tags) {
-    final displayTags = tags.take(3).toList();
+    final count = tags.length.clamp(0, AppConstants.tagCardDisplayLimit);
+    final remaining = tags.length - count;
     return Wrap(
       spacing: AppSpacing.xs,
       runSpacing: AppSpacing.xs,
       children: [
-        for (int i = 0; i < displayTags.length; i++)
-          ModernChip.tonedTag(displayTags[i], index: i),
+        for (int i = 0; i < count; i++) ModernChip.tonedTag(tags[i], index: i),
+        if (remaining > 0) ModernChip.tag(label: '+$remaining'),
       ],
     );
   }

--- a/lib/widgets/recent_diaries_widget.dart
+++ b/lib/widgets/recent_diaries_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../constants/app_constants.dart';
 import '../models/diary_entry.dart';
 import '../ui/design_system/app_spacing.dart';
 import '../ui/design_system/app_typography.dart';
@@ -162,10 +163,15 @@ class RecentDiariesWidget extends StatelessWidget {
   }
 
   Widget _buildTags(BuildContext context, List<String> tags) {
+    final count = tags.length.clamp(0, AppConstants.tagCardDisplayLimit);
+    final remaining = tags.length - count;
     return Wrap(
       spacing: AppSpacing.xs,
       runSpacing: AppSpacing.xs,
-      children: tags.take(3).map((tag) => ModernChip.tag(label: tag)).toList(),
+      children: [
+        for (int i = 0; i < count; i++) ModernChip.tag(label: tags[i]),
+        if (remaining > 0) ModernChip.tag(label: '+$remaining'),
+      ],
     );
   }
 }

--- a/lib/widgets/timeline/timeline_photo_widget.dart
+++ b/lib/widgets/timeline/timeline_photo_widget.dart
@@ -256,7 +256,9 @@ class _TimelinePhotoWidgetState extends State<TimelinePhotoWidget> {
                   child: Center(
                     child: Text(
                       context.l10n.photoNoPhotosMessage,
-                      style: TextStyle(color: Colors.grey[600]),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- タグが3件を超える場合に `+N` バッジを表示し、切り捨てを明示
- `AppConstants.tagCardDisplayLimit = 3` を共通定数として抽出
- `diary_card_widget` と `recent_diaries_widget` の両方に一貫して適用
- タイムライン空状態テキストのダークモード対応（`Colors.grey[600]` → `colorScheme.onSurfaceVariant`）

## Test Plan
- 日記一覧でタグが4件以上ある日記に `+N` バッジが表示されることを確認
- タグが3件以下の場合はバッジが表示されないことを確認
- ダークモードでタイムラインの空状態テキストが適切なコントラストで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)