### PR TITLE
refactor: unify PromptCacheService.build() return type to Result<void>

### DIFF
--- a/lib/services/prompt_cache_service.dart
+++ b/lib/services/prompt_cache_service.dart
@@ -22,6 +22,7 @@ final class PromptCacheService {
 
   /// 全プロンプトリストから3種キャッシュを一括構築する
   Result<void> build(List<WritingPrompt> prompts) {
+    _isBuilt = false;
     try {
       _planFilterCache.clear();
       _categoryCache.clear();

--- a/lib/services/prompt_cache_service.dart
+++ b/lib/services/prompt_cache_service.dart
@@ -51,7 +51,7 @@ final class PromptCacheService {
       return const Success(null);
     } catch (e) {
       _logger.error('PromptCacheService: Cache build failed', error: e);
-      return Failure(ServiceException('Cache build failed: ${e.toString()}'));
+      return Failure(ServiceException('Cache build failed', originalError: e));
     }
   }
 

--- a/lib/services/prompt_cache_service.dart
+++ b/lib/services/prompt_cache_service.dart
@@ -1,3 +1,5 @@
+import '../core/errors/app_exceptions.dart';
+import '../core/result/result.dart';
 import '../models/writing_prompt.dart';
 import '../utils/prompt_category_utils.dart';
 import 'interfaces/logging_service_interface.dart';
@@ -19,7 +21,7 @@ final class PromptCacheService {
   bool get isBuilt => _isBuilt;
 
   /// 全プロンプトリストから3種キャッシュを一括構築する
-  void build(List<WritingPrompt> prompts) {
+  Result<void> build(List<WritingPrompt> prompts) {
     try {
       _planFilterCache.clear();
       _categoryCache.clear();
@@ -46,9 +48,10 @@ final class PromptCacheService {
 
       _isBuilt = true;
       _logger.info('PromptCacheService: Cache build completed');
+      return const Success(null);
     } catch (e) {
       _logger.error('PromptCacheService: Cache build failed', error: e);
-      rethrow;
+      return Failure(ServiceException('Cache build failed: ${e.toString()}'));
     }
   }
 

--- a/lib/services/prompt_service.dart
+++ b/lib/services/prompt_service.dart
@@ -49,12 +49,7 @@ class PromptService implements IPromptService {
         return true;
       }
       await _loadPromptsFromAsset();
-      final buildResult = _cacheService.build(_allPrompts);
-      if (buildResult is Failure) {
-        _logger.error(
-          'PromptService: Cache build failed',
-          error: buildResult.exception,
-        );
+      if (_cacheService.build(_allPrompts).isFailure) {
         return false;
       }
       _isInitialized = true;
@@ -207,15 +202,12 @@ class PromptService implements IPromptService {
 
   @override
   void clearCache() {
-    _cacheService.clear();
     if (_isInitialized) {
-      final buildResult = _cacheService.build(_allPrompts);
-      if (buildResult is Failure) {
-        _logger.error(
-          'PromptService: Cache rebuild failed',
-          error: buildResult.exception,
-        );
+      if (_cacheService.build(_allPrompts).isFailure) {
+        _isInitialized = false;
       }
+    } else {
+      _cacheService.clear();
     }
   }
 

--- a/lib/services/prompt_service.dart
+++ b/lib/services/prompt_service.dart
@@ -49,7 +49,14 @@ class PromptService implements IPromptService {
         return true;
       }
       await _loadPromptsFromAsset();
-      _cacheService.build(_allPrompts);
+      final buildResult = _cacheService.build(_allPrompts);
+      if (buildResult is Failure) {
+        _logger.error(
+          'PromptService: Cache build failed',
+          error: buildResult.exception,
+        );
+        return false;
+      }
       _isInitialized = true;
       _logger.info(
         'PromptService: Initialization completed (prompt count: ${_allPrompts.length})',
@@ -202,7 +209,13 @@ class PromptService implements IPromptService {
   void clearCache() {
     _cacheService.clear();
     if (_isInitialized) {
-      _cacheService.build(_allPrompts);
+      final buildResult = _cacheService.build(_allPrompts);
+      if (buildResult is Failure) {
+        _logger.error(
+          'PromptService: Cache rebuild failed',
+          error: buildResult.exception,
+        );
+      }
     }
   }
 

--- a/test/unit/services/prompt_cache_service_test.dart
+++ b/test/unit/services/prompt_cache_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/models/writing_prompt.dart';
 import 'package:smart_photo_diary/services/prompt_cache_service.dart';
 import '../helpers/writing_prompt_test_helpers.dart';
@@ -12,15 +13,17 @@ void main() {
     });
 
     group('build()', () {
-      test('正常なリストで isBuilt が true になる', () {
-        cache.build([
+      test('正常なリストで Success を返し isBuilt が true になる', () {
+        final result = cache.build([
           makeWritingPrompt(id: 'p1', category: PromptCategory.emotion),
         ]);
+        expect(result, isA<Success<void>>());
         expect(cache.isBuilt, true);
       });
 
-      test('空リストで例外が発生しない', () {
-        expect(() => cache.build([]), returnsNormally);
+      test('空リストで Success を返す', () {
+        final result = cache.build([]);
+        expect(result, isA<Success<void>>());
         expect(cache.isBuilt, true);
       });
     });


### PR DESCRIPTION
## Summary
- Change `PromptCacheService.build()` return type from `void` to `Result<void>` to align with the project's Result pattern guidelines
- Replace `rethrow` with `Failure(ServiceException(..., originalError: e))` to preserve original error context
- Update `PromptService` callers to handle `Result<void>` instead of catching exceptions
- Fix state inconsistency in `clearCache()`: set `_isInitialized = false` when cache rebuild fails to prevent serving stale/empty cache in initialized state
- Remove redundant `_cacheService.clear()` before `build()` in `clearCache()` (build() already clears internally)
- Remove duplicate error logging in `PromptService` (PromptCacheService owns its error reporting)
- Update `PromptCacheService` tests to assert `Success<void>` return value

Closes #114

## Test Plan
- `fvm flutter test test/unit/services/prompt_cache_service_test.dart` — all 12 tests pass
- `fvm flutter test test/unit/services/prompt_service_test.dart` — all 35 tests pass
- `fvm flutter analyze` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * キャッシュ操作時のエラーハンドリングが改善され、エラー発生時により詳細で一貫性のあるエラー情報が提供されるようになりました。
  * アプリケーション初期化時のキャッシュ構築・再構築の安定性が向上し、エラー時の回復処理が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->