### PR TITLE
refactor: migrate PhotoFilterService.getScreenshotAssetIds to Result<Set<String>>

### DIFF
--- a/lib/screens/home/home_data_loader.dart
+++ b/lib/screens/home/home_data_loader.dart
@@ -43,8 +43,10 @@ mixin _HomeDataLoaderMixin on State<HomeScreen> {
 
       // Pre-fetch screenshot asset IDs for filtering
       if (_self._photoTypeFilter == PhotoTypeFilter.photosOnly) {
-        _self._screenshotAssetIds =
-            await PhotoFilterService.getScreenshotAssetIds(_self._logger);
+        final idsResult = await PhotoFilterService.getScreenshotAssetIds(
+          _self._logger,
+        );
+        _self._screenshotAssetIds = idsResult.getOrDefault({});
       } else {
         _self._screenshotAssetIds = {};
       }

--- a/lib/services/photo_filter_service.dart
+++ b/lib/services/photo_filter_service.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:photo_manager/photo_manager.dart';
+import '../core/errors/app_exceptions.dart';
+import '../core/result/result.dart';
 import '../models/photo_type_filter.dart';
 import 'interfaces/logging_service_interface.dart';
 
@@ -12,10 +14,10 @@ final class PhotoFilterService {
   ///
   /// iOSでは「スクリーンショット」スマートアルバムに属するアセットのIDを返す。
   /// Androidでは空セットを返す（relativePathベースで判定するため不要）。
-  static Future<Set<String>> getScreenshotAssetIds([
+  static Future<Result<Set<String>>> getScreenshotAssetIds([
     ILoggingService? logger,
   ]) async {
-    if (!Platform.isIOS) return {};
+    if (!Platform.isIOS) return const Success({});
 
     try {
       // PMDarwinPathFilterでスクリーンショットスマートアルバムを直接取得（ロケール非依存）
@@ -31,23 +33,28 @@ final class PhotoFilterService {
       );
 
       final screenshotAlbum = albums.firstOrNull;
-      if (screenshotAlbum == null) return {};
+      if (screenshotAlbum == null) return const Success({});
 
       final count = await screenshotAlbum.assetCountAsync;
-      if (count == 0) return {};
+      if (count == 0) return const Success({});
 
       final assets = await screenshotAlbum.getAssetListRange(
         start: 0,
         end: count,
       );
-      return assets.map((a) => a.id).toSet();
+      return Success(assets.map((a) => a.id).toSet());
     } catch (e) {
       logger?.warning(
         'Failed to get screenshot asset IDs',
         context: 'PhotoFilterService.getScreenshotAssetIds',
         data: 'error: $e',
       );
-      return {};
+      return Failure(
+        PhotoAccessException(
+          'Failed to get screenshot asset IDs',
+          originalError: e,
+        ),
+      );
     }
   }
 

--- a/test/unit/services/photo_filter_service_test.dart
+++ b/test/unit/services/photo_filter_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/models/photo_type_filter.dart';
 import 'package:smart_photo_diary/services/photo_filter_service.dart';
 
@@ -19,6 +20,15 @@ MockAssetEntity createMockAsset(
 }
 
 void main() {
+  group('PhotoFilterService.getScreenshotAssetIds', () {
+    test('returns Success with empty set on non-iOS platforms', () async {
+      // On test host (macOS/Linux/Windows), Platform.isIOS is false
+      final result = await PhotoFilterService.getScreenshotAssetIds();
+      expect(result, isA<Success<Set<String>>>());
+      expect((result as Success<Set<String>>).data, isEmpty);
+    });
+  });
+
   group('PhotoFilterService.filterByPhotoType', () {
     late List<MockAssetEntity> assets;
     const emptyScreenshotIds = <String>{};


### PR DESCRIPTION
## Summary
- `PhotoFilterService.getScreenshotAssetIds` の戻り値を `Future<Set<String>>` から `Future<Result<Set<String>>>` に変更
- 取得失敗時は `Failure(PhotoAccessException)` を返すよう修正（従来は空の Set を返していた）
- 呼び出し元 `home_data_loader.dart` を `idsResult.getOrDefault({})` で対応（フォールバック挙動は維持）
- テストに `getScreenshotAssetIds` の非 iOS パスの検証を追加

## Test Plan
- `fvm flutter test test/unit/services/photo_filter_service_test.dart` — 全テスト通過
- `fvm flutter test` — 2018 テスト全通過
- `fvm flutter analyze` — No issues found

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)