### PR TITLE
chore: migrate release workflow to gh CLI and bump artifact action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           )
 
       - name: Upload iOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-release-artifacts
           path: ios-artifacts/*
@@ -115,31 +115,39 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download iOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ios-release-artifacts
           path: ./artifacts/ios
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.version.outputs.version }}
-          target_commitish: ${{ github.sha }}
-          name: "Smart Photo Diary ${{ needs.version.outputs.version }}"
-          draft: true
-          prerelease: ${{ contains(needs.version.outputs.version, '-') }}
-          files: |
-            artifacts/ios/smart-photo-diary-ios-*.zip
-            artifacts/ios/smart-photo-diary-checksums.txt
-          body: |
-            Build artifacts for Smart Photo Diary ${{ needs.version.outputs.version }}
-
-            **Build Info:** ${{ needs.version.outputs.version_name }} (Build ${{ needs.version.outputs.build_number }})
-            **Commit:** ${{ github.sha }}
-
-            Release notes will be updated manually.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+          VERSION_NAME: ${{ needs.version.outputs.version_name }}
+          BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" == *"-"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          NOTES="Build artifacts for Smart Photo Diary $VERSION
+
+**Build Info:** $VERSION_NAME (Build $BUILD_NUMBER)
+**Commit:** $COMMIT_SHA
+
+Release notes will be updated manually."
+
+          gh release create "$VERSION" \
+            --title "Smart Photo Diary $VERSION" \
+            --target "$COMMIT_SHA" \
+            --draft \
+            ${PRERELEASE_FLAG:+"$PRERELEASE_FLAG"} \
+            --notes "$NOTES" \
+            artifacts/ios/smart-photo-diary-ios-*.zip \
+            artifacts/ios/smart-photo-diary-checksums.txt
 
       - name: Create release summary
         env:


### PR DESCRIPTION
## Summary
- Replace `softprops/action-gh-release@v2` (Node.js 20) with native `gh release create` to eliminate Node.js dependency entirely
- Upgrade `actions/upload-artifact@v4` → `v7` for Node.js 24 compatibility
- Upgrade `actions/download-artifact@v4` → `v8` for Node.js 24 compatibility
- Inline prerelease detection in shell (`[[ "$VERSION" == *"-"* ]]`) instead of passing as env var

## Test Plan
- [ ] Verify workflow runs successfully on next tag push
- [ ] Confirm GitHub Release is created as draft with correct title, notes, and artifacts
- [ ] Confirm prerelease flag is set correctly for pre-release tags (e.g. `v1.0.0-beta.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)