### PR TITLE
chore: bump Android NDK version to 28.2.13676358

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.focuswave.dev.smartPhotoDiary"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- Update `ndkVersion` in `android/app/build.gradle.kts` from `27.0.12077973` to `28.2.13676358`
- The `jni` plugin requires NDK 28.2.13676358; this aligns the project config with the plugin dependency

## Test Plan
- Run `fvm flutter build apk --debug` and verify the NDK version mismatch warning no longer appears