### PR TITLE
feat(purchase): reflect premium state immediately after purchase completes

### DIFF
--- a/lib/controllers/settings_controller.dart
+++ b/lib/controllers/settings_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:package_info_plus/package_info_plus.dart';
@@ -106,6 +107,24 @@ class SettingsController extends BaseErrorController {
 
   /// 外部からUI再構築をトリガーするための公開メソッド
   void notifyStateChanged() {
+    unawaited(_refetchSubscriptionAndNotify());
+  }
+
+  Future<void> _refetchSubscriptionAndNotify() async {
+    if (_settingsService == null) {
+      notifyListeners();
+      return;
+    }
+    final result = await _settingsService!.getSubscriptionInfoV2();
+    if (result.isSuccess) {
+      _subscriptionInfo = result.value;
+    } else {
+      _logger.warning(
+        'Failed to refetch subscription info after state change',
+        context: 'SettingsController',
+        data: {'error': result.error.toString()},
+      );
+    }
     notifyListeners();
   }
 }

--- a/lib/controllers/settings_controller.dart
+++ b/lib/controllers/settings_controller.dart
@@ -111,11 +111,13 @@ class SettingsController extends BaseErrorController {
   }
 
   Future<void> _refetchSubscriptionAndNotify() async {
+    final localVersion = ++_requestVersion;
     if (_settingsService == null) {
-      notifyListeners();
+      if (!_isDisposed) notifyListeners();
       return;
     }
     final result = await _settingsService!.getSubscriptionInfoV2();
+    if (localVersion != _requestVersion || _isDisposed) return;
     if (result.isSuccess) {
       _subscriptionInfo = result.value;
     } else {
@@ -126,5 +128,13 @@ class SettingsController extends BaseErrorController {
       );
     }
     notifyListeners();
+  }
+
+  bool _isDisposed = false;
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
   }
 }

--- a/lib/controllers/upgrade_dialog_controller.dart
+++ b/lib/controllers/upgrade_dialog_controller.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
 import '../core/errors/app_exceptions.dart';
 import '../models/plans/plan.dart';
 import '../models/plans/plan_factory.dart';
@@ -29,6 +33,9 @@ class UpgradeDialogController extends BaseErrorController {
   UpgradeDialogState _state = UpgradeDialogState.loadingPrices;
   List<Plan> _plans = [];
   Map<String, String> _priceStrings = {};
+  bool _isDisposed = false;
+  StreamSubscription<PurchaseResult>? _purchaseSub;
+  final Duration _purchaseTimeout;
 
   /// 現在の状態
   UpgradeDialogState get state => _state;
@@ -42,8 +49,10 @@ class UpgradeDialogController extends BaseErrorController {
   UpgradeDialogController({
     required ILoggingService logger,
     required ISubscriptionService subscriptionService,
+    @visibleForTesting Duration purchaseTimeout = const Duration(minutes: 3),
   }) : _logger = logger,
-       _subscriptionService = subscriptionService;
+       _subscriptionService = subscriptionService,
+       _purchaseTimeout = purchaseTimeout;
 
   /// プラン情報と価格を読み込む
   Future<bool> loadPlansAndPrices({required String locale}) async {
@@ -91,17 +100,43 @@ class UpgradeDialogController extends BaseErrorController {
   }
 
   /// プランを購入する
-  Future<void> purchasePlan(Plan plan) async {
+  ///
+  /// 購入フローを最後まで実行した場合 true、既に購入中でスキップした場合 false を返す。
+  /// 呼び出し元は false の場合にダイアログを閉じない等の制御ができる。
+  Future<bool> purchasePlan(Plan plan) async {
     if (_state == UpgradeDialogState.purchasing) {
       _logger.warning(
         'Purchase already in progress; skipping',
         context: 'UpgradeDialogController.purchasePlan',
       );
-      return;
+      return false;
     }
 
     _state = UpgradeDialogState.purchasing;
-    notifyListeners();
+    if (!_isDisposed) notifyListeners();
+
+    // buyNonConsumable より前に購読してイベント取りこぼしを防ぐ
+    final completer = Completer<PurchaseResult>();
+    _purchaseSub = _subscriptionService.purchaseStream.listen(
+      (result) {
+        final matchesProduct =
+            result.productId == null || result.productId == plan.productId;
+        if (result.isTerminal && matchesProduct && !completer.isCompleted) {
+          completer.complete(result);
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        if (!completer.isCompleted) {
+          completer.complete(
+            PurchaseResult(
+              status: PurchaseStatus.error,
+              productId: plan.productId,
+              errorMessage: e.toString(),
+            ),
+          );
+        }
+      },
+    );
 
     try {
       _logger.info(
@@ -110,20 +145,10 @@ class UpgradeDialogController extends BaseErrorController {
         data: {'productId': plan.productId, 'price': plan.price},
       );
 
-      final result = await _subscriptionService.purchasePlanClass(plan);
+      final initResult = await _subscriptionService.purchasePlanClass(plan);
 
-      if (result.isSuccess) {
-        final purchaseResult = result.value;
-        _logger.info(
-          'Purchase succeeded',
-          context: 'UpgradeDialogController.purchasePlan',
-          data: {
-            'status': purchaseResult.status.toString(),
-            'productId': purchaseResult.productId,
-          },
-        );
-      } else {
-        final error = result.error;
+      if (initResult.isFailure) {
+        final error = initResult.error;
         if (error.message.contains('In-App Purchase not available') ||
             error.message.contains('Product not found')) {
           _logger.warning(
@@ -133,25 +158,67 @@ class UpgradeDialogController extends BaseErrorController {
           );
         } else {
           _logger.error(
-            'Purchase failed',
+            'Purchase initiation failed',
             context: 'UpgradeDialogController.purchasePlan',
             error: error,
           );
         }
+        if (!completer.isCompleted) {
+          completer.complete(
+            PurchaseResult(
+              status: PurchaseStatus.error,
+              productId: plan.productId,
+              errorMessage: error.message,
+            ),
+          );
+        }
+      } else if (initResult.value.status == PurchaseStatus.purchased) {
+        if (!completer.isCompleted) {
+          completer.complete(initResult.value);
+        }
       }
+
+      final finalResult = await completer.future.timeout(
+        _purchaseTimeout,
+        onTimeout: () => PurchaseResult(
+          status: PurchaseStatus.error,
+          productId: plan.productId,
+          errorMessage: 'Purchase timed out after $_purchaseTimeout',
+        ),
+      );
+
+      _logger.info(
+        'Purchase flow finished',
+        context: 'UpgradeDialogController.purchasePlan',
+        data: {
+          'status': finalResult.status.toString(),
+          'productId': finalResult.productId,
+        },
+      );
     } catch (e) {
       _logger.error(
-        'Unexpected error occurred',
+        'Unexpected error in purchase flow',
         context: 'UpgradeDialogController.purchasePlan',
         error: e,
       );
     } finally {
+      await _purchaseSub?.cancel();
+      _purchaseSub = null;
       _state = UpgradeDialogState.showingPlans;
-      notifyListeners();
+      if (!_isDisposed) notifyListeners();
       _logger.debug(
         'Purchase flow finished, resetting state',
         context: 'UpgradeDialogController.purchasePlan',
       );
     }
+    return true;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _purchaseSub?.cancel();
+    _purchaseSub = null;
+    super.dispose();
   }
 }

--- a/lib/controllers/upgrade_dialog_controller.dart
+++ b/lib/controllers/upgrade_dialog_controller.dart
@@ -117,28 +117,27 @@ class UpgradeDialogController extends BaseErrorController {
 
     // buyNonConsumable より前に購読してイベント取りこぼしを防ぐ
     final completer = Completer<PurchaseResult>();
-    _purchaseSub = _subscriptionService.purchaseStream.listen(
-      (result) {
-        final matchesProduct =
-            result.productId == null || result.productId == plan.productId;
-        if (result.isTerminal && matchesProduct && !completer.isCompleted) {
-          completer.complete(result);
-        }
-      },
-      onError: (Object e, StackTrace st) {
-        if (!completer.isCompleted) {
-          completer.complete(
-            PurchaseResult(
-              status: PurchaseStatus.error,
-              productId: plan.productId,
-              errorMessage: e.toString(),
-            ),
-          );
-        }
-      },
-    );
-
     try {
+      _purchaseSub = _subscriptionService.purchaseStream.listen(
+        (result) {
+          final matchesProduct =
+              result.productId == null || result.productId == plan.productId;
+          if (result.isTerminal && matchesProduct && !completer.isCompleted) {
+            completer.complete(result);
+          }
+        },
+        onError: (Object e, StackTrace st) {
+          if (!completer.isCompleted) {
+            completer.complete(
+              PurchaseResult(
+                status: PurchaseStatus.error,
+                productId: plan.productId,
+                errorMessage: e.toString(),
+              ),
+            );
+          }
+        },
+      );
       _logger.info(
         'Purchase flow started: ${plan.id}',
         context: 'UpgradeDialogController.purchasePlan',
@@ -201,6 +200,7 @@ class UpgradeDialogController extends BaseErrorController {
         context: 'UpgradeDialogController.purchasePlan',
         error: e,
       );
+      return false;
     } finally {
       await _purchaseSub?.cancel();
       _purchaseSub = null;

--- a/lib/services/interfaces/in_app_purchase_service_interface.dart
+++ b/lib/services/interfaces/in_app_purchase_service_interface.dart
@@ -153,6 +153,15 @@ class PurchaseResult {
   /// 購入が失敗したかどうか
   bool get isError => status == PurchaseStatus.error;
 
+  /// ストリームの終端イベントかどうか（完了・失敗・キャンセルを含む）
+  bool get isTerminal =>
+      status == PurchaseStatus.purchased ||
+      status == PurchaseStatus.restored ||
+      status == PurchaseStatus.cancelled ||
+      status == PurchaseStatus.error ||
+      status == PurchaseStatus.networkError ||
+      status == PurchaseStatus.storeNotAvailable;
+
   @override
   String toString() {
     return 'PurchaseResult(status: $status, productId: $productId, '

--- a/lib/services/interfaces/in_app_purchase_service_interface.dart
+++ b/lib/services/interfaces/in_app_purchase_service_interface.dart
@@ -159,8 +159,10 @@ class PurchaseResult {
       status == PurchaseStatus.restored ||
       status == PurchaseStatus.cancelled ||
       status == PurchaseStatus.error ||
+      status == PurchaseStatus.productNotFound ||
       status == PurchaseStatus.networkError ||
-      status == PurchaseStatus.storeNotAvailable;
+      status == PurchaseStatus.storeNotAvailable ||
+      status == PurchaseStatus.alreadyOwned;
 
   @override
   String toString() {

--- a/lib/widgets/home_content_widget.dart
+++ b/lib/widgets/home_content_widget.dart
@@ -258,7 +258,9 @@ class _HomeContentWidgetState extends State<HomeContentWidget> {
     }
   }
 
-  void _navigateToUpgrade(BuildContext context) {
-    UpgradeDialogUtils.showUpgradeDialog(context);
+  Future<void> _navigateToUpgrade(BuildContext context) async {
+    await UpgradeDialogUtils.showUpgradeDialog(context);
+    if (!mounted) return;
+    await _loadUsageSummary();
   }
 }

--- a/lib/widgets/upgrade/upgrade_dialog.dart
+++ b/lib/widgets/upgrade/upgrade_dialog.dart
@@ -13,7 +13,7 @@ import 'premium_bullet_list.dart';
 class UpgradeDialog extends StatelessWidget {
   final List<Plan> plans;
   final Map<String, String> priceStrings;
-  final void Function(Plan plan) onPlanSelected;
+  final Future<bool> Function(Plan plan) onPlanSelected;
 
   const UpgradeDialog({
     super.key,
@@ -42,9 +42,9 @@ class UpgradeDialog extends StatelessWidget {
                 plan: plan,
                 priceString: priceStrings[plan.id],
                 onTap: () async {
-                  Navigator.of(context).pop();
                   await Future.delayed(AppConstants.quickAnimationDuration);
-                  onPlanSelected(plan);
+                  final started = await onPlanSelected(plan);
+                  if (started && context.mounted) Navigator.of(context).pop();
                 },
               ),
             ),

--- a/test/unit/controllers/settings_controller_test.dart
+++ b/test/unit/controllers/settings_controller_test.dart
@@ -6,6 +6,8 @@ import 'package:smart_photo_diary/controllers/settings_controller.dart';
 import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
 import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/core/service_locator.dart';
+import 'package:smart_photo_diary/models/subscription_info_v2.dart';
+import 'package:smart_photo_diary/models/subscription_status.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/settings_service_interface.dart';
 
@@ -105,6 +107,69 @@ void main() {
         controller.onLocaleChanged(null);
 
         expect(controller.selectedLocale, isNull);
+      });
+    });
+
+    group('notifyStateChanged', () {
+      test('subscriptionInfo を再フェッチして notifyListeners を呼ぶ', () async {
+        final mockInfo = SubscriptionInfoV2.fromStatus(SubscriptionStatus());
+        when(
+          () => mockSettings.getSubscriptionInfoV2(),
+        ).thenAnswer((_) async => Success(mockInfo));
+
+        final controller = SettingsController(
+          logger: mockLogger,
+          settingsService: mockSettings,
+        );
+        addTearDown(controller.dispose);
+
+        int notifyCount = 0;
+        controller.addListener(() => notifyCount++);
+
+        controller.notifyStateChanged();
+        // fire-and-forget なので完了を待つ
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+
+        verify(() => mockSettings.getSubscriptionInfoV2()).called(1);
+        expect(controller.subscriptionInfo, mockInfo);
+        expect(notifyCount, 1);
+      });
+
+      test('getSubscriptionInfoV2 が Failure でも notifyListeners を呼ぶ', () async {
+        when(
+          () => mockSettings.getSubscriptionInfoV2(),
+        ).thenAnswer((_) async => const Failure(ServiceException('error')));
+
+        final controller = SettingsController(
+          logger: mockLogger,
+          settingsService: mockSettings,
+        );
+        addTearDown(controller.dispose);
+
+        int notifyCount = 0;
+        controller.addListener(() => notifyCount++);
+
+        controller.notifyStateChanged();
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+
+        expect(notifyCount, 1);
+        expect(controller.subscriptionInfo, isNull);
+      });
+
+      test('settingsService が null の場合も notifyListeners を呼ぶ', () async {
+        final controller = SettingsController(logger: mockLogger);
+        addTearDown(controller.dispose);
+
+        int notifyCount = 0;
+        controller.addListener(() => notifyCount++);
+
+        controller.notifyStateChanged();
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+
+        expect(notifyCount, 1);
       });
     });
 

--- a/test/unit/controllers/upgrade_dialog_controller_test.dart
+++ b/test/unit/controllers/upgrade_dialog_controller_test.dart
@@ -1,0 +1,288 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:smart_photo_diary/controllers/upgrade_dialog_controller.dart';
+import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
+import 'package:smart_photo_diary/models/plans/premium_monthly_plan.dart';
+import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/subscription_service_interface.dart';
+
+class MockLoggingService extends Mock implements ILoggingService {}
+
+class MockSubscriptionService extends Mock implements ISubscriptionService {}
+
+void main() {
+  late MockLoggingService mockLogger;
+  late MockSubscriptionService mockSubscription;
+
+  setUp(() {
+    mockLogger = MockLoggingService();
+    mockSubscription = MockSubscriptionService();
+
+    when(
+      () => mockLogger.info(
+        any(),
+        context: any(named: 'context'),
+        data: any(named: 'data'),
+      ),
+    ).thenReturn(null);
+    when(
+      () => mockLogger.debug(
+        any(),
+        context: any(named: 'context'),
+        data: any(named: 'data'),
+      ),
+    ).thenReturn(null);
+    when(
+      () => mockLogger.warning(
+        any(),
+        context: any(named: 'context'),
+        data: any(named: 'data'),
+      ),
+    ).thenReturn(null);
+    when(
+      () => mockLogger.error(
+        any(),
+        context: any(named: 'context'),
+        error: any(named: 'error'),
+      ),
+    ).thenReturn(null);
+  });
+
+  UpgradeDialogController createController({
+    Stream<PurchaseResult>? purchaseStream,
+  }) {
+    final stream = purchaseStream ?? const Stream<PurchaseResult>.empty();
+    when(() => mockSubscription.purchaseStream).thenAnswer((_) => stream);
+    return UpgradeDialogController(
+      logger: mockLogger,
+      subscriptionService: mockSubscription,
+    );
+  }
+
+  final plan = PremiumMonthlyPlan();
+
+  group('UpgradeDialogController.purchasePlan', () {
+    test('購入 pending → purchased でシュミレートすると showingPlans に戻る', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      final controller = createController(
+        purchaseStream: streamController.stream,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      final purchaseFuture = controller.purchasePlan(plan);
+      expect(controller.state, UpgradeDialogState.purchasing);
+
+      streamController.add(
+        PurchaseResult(
+          status: PurchaseStatus.purchased,
+          productId: plan.productId,
+        ),
+      );
+
+      expect(await purchaseFuture, true);
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('キャンセル時も showingPlans に戻る', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      final controller = createController(
+        purchaseStream: streamController.stream,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      final purchaseFuture = controller.purchasePlan(plan);
+      streamController.add(
+        PurchaseResult(
+          status: PurchaseStatus.cancelled,
+          productId: plan.productId,
+        ),
+      );
+
+      await purchaseFuture;
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('エラーイベント受信時も showingPlans に戻る', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      final controller = createController(
+        purchaseStream: streamController.stream,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      final purchaseFuture = controller.purchasePlan(plan);
+      streamController.add(
+        PurchaseResult(status: PurchaseStatus.error, productId: plan.productId),
+      );
+
+      await purchaseFuture;
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('別 productId のイベントは無視し、本命 productId で完了する', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      final controller = createController(
+        purchaseStream: streamController.stream,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      final purchaseFuture = controller.purchasePlan(plan);
+
+      // 別プランのイベント（無視されるべき）
+      streamController.add(
+        const PurchaseResult(
+          status: PurchaseStatus.purchased,
+          productId: 'other_product',
+        ),
+      );
+      await Future.delayed(Duration.zero);
+      // まだ purchasing 状態のまま
+      expect(controller.state, UpgradeDialogState.purchasing);
+
+      // 本命プランのイベント
+      streamController.add(
+        PurchaseResult(
+          status: PurchaseStatus.purchased,
+          productId: plan.productId,
+        ),
+      );
+      await purchaseFuture;
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('purchasePlanClass が Failure の場合は即完了して showingPlans に戻る', () async {
+      final controller = createController();
+      addTearDown(controller.dispose);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => const Failure(ServiceException('Purchase not available')),
+      );
+
+      await controller.purchasePlan(plan);
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('シミュレータモック経路: purchasePlanClass が Success(purchased) を即返す', () async {
+      final controller = createController();
+      addTearDown(controller.dispose);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.purchased,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      await controller.purchasePlan(plan);
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+
+    test('同時購入リクエストは無視される', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      final controller = createController(
+        purchaseStream: streamController.stream,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      final first = controller.purchasePlan(plan);
+      final second = controller.purchasePlan(plan);
+
+      streamController.add(
+        PurchaseResult(
+          status: PurchaseStatus.purchased,
+          productId: plan.productId,
+        ),
+      );
+
+      expect(await first, true);
+      // 2回目はガード発動で false
+      expect(await second, false);
+
+      // purchasePlanClass は1回だけ呼ばれる
+      verify(() => mockSubscription.purchasePlanClass(plan)).called(1);
+    });
+
+    test('タイムアウト後に showingPlans に戻る', () async {
+      final streamController = StreamController<PurchaseResult>.broadcast();
+      when(
+        () => mockSubscription.purchaseStream,
+      ).thenAnswer((_) => streamController.stream);
+
+      // テスト用に短いタイムアウトを注入
+      final controller = UpgradeDialogController(
+        logger: mockLogger,
+        subscriptionService: mockSubscription,
+        purchaseTimeout: const Duration(milliseconds: 50),
+      );
+      addTearDown(controller.dispose);
+      addTearDown(streamController.close);
+
+      when(() => mockSubscription.purchasePlanClass(plan)).thenAnswer(
+        (_) async => Success(
+          PurchaseResult(
+            status: PurchaseStatus.pending,
+            productId: plan.productId,
+          ),
+        ),
+      );
+
+      await controller.purchasePlan(plan);
+      // タイムアウト後に purchasing → showingPlans に遷移する
+      expect(controller.state, UpgradeDialogState.showingPlans);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `UpgradeDialogController.purchasePlan` が `purchaseStream` を購読し、StoreKit の購入確定イベントを待ってから return するよう変更。これにより呼び出し側（設定画面・ホーム画面）がダイアログを閉じた直後に最新のプラン状態を取得できる
- `UpgradeDialog.onTap` の順序を「先に閉じて購入開始」から「購入完了後に閉じる」へ変更。`purchasePlan` が `bool` を返すことで二重タップ時の誤 pop も防止
- `SettingsController.notifyStateChanged()` を `subscriptionInfo` 再フェッチ後に `notifyListeners()` を呼ぶ実装に強化
- `HomeContentWidget._navigateToUpgrade` でダイアログ完了後に `_loadUsageSummary()` を再実行
- `PurchaseResult.isTerminal` getter を追加し、終端ステータス判定を一元化

## Test Plan

- `test/unit/controllers/upgrade_dialog_controller_test.dart` を新規追加（8ケース: 正常購入・キャンセル・エラー・別productId混入・initiate失敗・シミュレータモック・同時リクエスト・タイムアウト）
- `test/unit/controllers/settings_controller_test.dart` に `notifyStateChanged` の3ケースを追加
- `fvm flutter test` 2028件全通過
- 手動: サンドボックス Apple ID でプラン購入後、ダイアログが閉じた瞬間にホームのヘッダーピルと設定画面のプラン表示が即時更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 購入フローにタイムアウト処理を追加しました。

* **Bug Fixes**
  * アップグレードダイアログでの重複購入リクエストをガードするようになりました。
  * ダイアログ表示後、使用状況情報が正しく更新されるようになりました。
  * 購入結果の終端状態判定処理を改善しました。

* **Tests**
  * 購入フロー関連のユニットテストを充実させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->