### PR TITLE
fix: sync subscription state with App Store on startup to fix sandbox account mismatch

### DIFF
--- a/lib/constants/subscription_constants.dart
+++ b/lib/constants/subscription_constants.dart
@@ -59,6 +59,13 @@ class SubscriptionConstants {
   /// サブスクリプション状態管理用のHiveボックス名
   static const String hiveBoxName = 'subscription_box';
 
+  // ========================================
+  // Store同期設定
+  // ========================================
+
+  /// 起動時Store同期のタイムアウト（restorePurchasesの結果待ち時間）
+  static const Duration storeSyncTimeout = Duration(seconds: 3);
+
   /// サブスクリプション状態のキー
   static const String statusKey = 'subscription_status';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'core/service_locator.dart';
 import 'services/interfaces/settings_service_interface.dart';
 import 'services/interfaces/logging_service_interface.dart';
 import 'core/service_registration.dart';
+import 'services/interfaces/in_app_purchase_service_interface.dart';
 import 'ui/design_system/app_theme.dart';
 import 'localization/localization_extensions.dart';
 import 'l10n/generated/app_localizations.dart';
@@ -67,6 +68,26 @@ Future<void> main() async {
 
   // スタートアップ時のデータベース最適化（fire-and-forget、アプリ起動をブロックしない）
   _optimizeDatabaseOnStartup(logger);
+  // スタートアップ時のStore購読状態同期（fire-and-forget、アプリ起動をブロックしない）
+  _syncSubscriptionOnStartup(logger);
+}
+
+Future<void> _syncSubscriptionOnStartup(ILoggingService logger) async {
+  final purchaseService = await serviceLocator
+      .getAsync<IInAppPurchaseService>();
+  final result = await purchaseService.syncSubscriptionWithStore();
+  result.fold(
+    (syncResult) => logger.info(
+      'Startup store sync completed',
+      context: 'main',
+      data: syncResult.toString(),
+    ),
+    (error) => logger.warning(
+      'Startup store sync failed',
+      context: 'main',
+      data: error.toString(),
+    ),
+  );
 }
 
 Future<void> _optimizeDatabaseOnStartup(ILoggingService logger) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,21 +73,29 @@ Future<void> main() async {
 }
 
 Future<void> _syncSubscriptionOnStartup(ILoggingService logger) async {
-  final purchaseService = await serviceLocator
-      .getAsync<IInAppPurchaseService>();
-  final result = await purchaseService.syncSubscriptionWithStore();
-  result.fold(
-    (syncResult) => logger.info(
-      'Startup store sync completed',
-      context: 'main',
-      data: syncResult.toString(),
-    ),
-    (error) => logger.warning(
+  try {
+    final purchaseService = await serviceLocator
+        .getAsync<IInAppPurchaseService>();
+    final result = await purchaseService.syncSubscriptionWithStore();
+    result.fold(
+      (syncResult) => logger.info(
+        'Startup store sync completed',
+        context: 'main',
+        data: syncResult.toString(),
+      ),
+      (error) => logger.warning(
+        'Startup store sync failed',
+        context: 'main',
+        data: error.toString(),
+      ),
+    );
+  } catch (e) {
+    logger.warning(
       'Startup store sync failed',
       context: 'main',
-      data: error.toString(),
-    ),
-  );
+      data: e.toString(),
+    );
+  }
 }
 
 Future<void> _optimizeDatabaseOnStartup(ILoggingService logger) async {

--- a/lib/services/in_app_purchase_service.dart
+++ b/lib/services/in_app_purchase_service.dart
@@ -8,10 +8,12 @@ import '../models/plans/plan.dart';
 import 'interfaces/in_app_purchase_service_interface.dart';
 import 'interfaces/subscription_state_service_interface.dart';
 import 'interfaces/logging_service_interface.dart';
+import 'interfaces/subscription_sync_result.dart';
 import 'mixins/service_logging.dart';
 import 'mixins/purchase_event_handler.dart';
 import 'purchase_product_delegate.dart';
 import 'purchase_flow_delegate.dart';
+import 'subscription_sync_delegate.dart';
 
 /// InAppPurchaseService
 ///
@@ -60,6 +62,7 @@ class InAppPurchaseService
   // デリゲート
   late final PurchaseProductDelegate _productDelegate;
   late final PurchaseFlowDelegate _flowDelegate;
+  late final SubscriptionSyncDelegate _syncDelegate;
 
   InAppPurchaseService({
     required ISubscriptionStateService stateService,
@@ -77,6 +80,12 @@ class InAppPurchaseService
       getIsPurchasing: () => _isPurchasing,
       setIsPurchasing: (value) => _isPurchasing = value,
       productDelegate: _productDelegate,
+      loggingService: _loggingService,
+    );
+    _syncDelegate = SubscriptionSyncDelegate(
+      getStateService: () => _stateService,
+      getInAppPurchase: () => _inAppPurchase,
+      purchaseStream: _purchaseStreamController.stream,
       loggingService: _loggingService,
     );
   }
@@ -171,6 +180,10 @@ class InAppPurchaseService
   @override
   Future<Result<List<PurchaseResult>>> restorePurchases() =>
       _flowDelegate.restorePurchases();
+
+  @override
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore() =>
+      _syncDelegate.syncSubscriptionWithStore();
 
   @override
   Future<Result<bool>> validatePurchase(String transactionId) async {

--- a/lib/services/interfaces/in_app_purchase_service_interface.dart
+++ b/lib/services/interfaces/in_app_purchase_service_interface.dart
@@ -1,5 +1,6 @@
 import '../../core/result/result.dart';
 import '../../models/plans/plan.dart';
+import 'subscription_sync_result.dart';
 
 /// In-App Purchase サービスのインターフェース
 ///
@@ -65,6 +66,16 @@ abstract class IInAppPurchaseService {
   ///
   /// 購入フローの進行状況や完了/失敗をリアルタイムで通知する。
   Stream<PurchaseResult> get purchaseStream;
+
+  /// 起動時にApp Storeと購読状態を同期する
+  ///
+  /// ローカルがPremiumなのにStoreに有効購読が無い場合はBasicへ降格する。
+  /// ネットワークエラー時は誤Basic化を防ぐため現状維持する。
+  ///
+  /// Returns:
+  /// - Success: [SubscriptionSyncResult]（同期結果）
+  /// - Failure: [ServiceException] 予期しない内部エラー時
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore();
 
   /// サービスを破棄
   ///

--- a/lib/services/interfaces/subscription_service_interface.dart
+++ b/lib/services/interfaces/subscription_service_interface.dart
@@ -2,6 +2,7 @@ import '../../core/result/result.dart';
 import '../../models/plans/plan.dart';
 import '../../models/subscription_status.dart';
 import 'in_app_purchase_service_interface.dart';
+import 'subscription_sync_result.dart';
 
 // データクラスを再エクスポート（後方互換性のため）
 export 'in_app_purchase_service_interface.dart'
@@ -222,6 +223,13 @@ abstract class ISubscriptionService {
 
   /// 購入状態変更を監視
   Stream<PurchaseResult> get purchaseStream;
+
+  /// 起動時にApp Storeと購読状態を同期する
+  ///
+  /// Returns:
+  /// - Success: [SubscriptionSyncResult]（同期結果）
+  /// - Failure: [ServiceException] 予期しない内部エラー時
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore();
 
   /// サービスを破棄
   Future<void> dispose();

--- a/lib/services/interfaces/subscription_sync_result.dart
+++ b/lib/services/interfaces/subscription_sync_result.dart
@@ -1,0 +1,44 @@
+enum SubscriptionSyncOutcome {
+  noChange,
+  synced,
+  downgradedToBasic,
+
+  /// IAP未初期化・stateService未初期化など前提条件不足
+  skipped,
+
+  /// ネットワークまたはStore通信失敗により現状維持
+  error,
+}
+
+class SubscriptionSyncResult {
+  final SubscriptionSyncOutcome outcome;
+  final int restoredCount;
+
+  const SubscriptionSyncResult._({
+    required this.outcome,
+    this.restoredCount = 0,
+  });
+
+  factory SubscriptionSyncResult.noChange() =>
+      const SubscriptionSyncResult._(outcome: SubscriptionSyncOutcome.noChange);
+
+  factory SubscriptionSyncResult.synced(int count) => SubscriptionSyncResult._(
+    outcome: SubscriptionSyncOutcome.synced,
+    restoredCount: count,
+  );
+
+  factory SubscriptionSyncResult.downgradedToBasic() =>
+      const SubscriptionSyncResult._(
+        outcome: SubscriptionSyncOutcome.downgradedToBasic,
+      );
+
+  factory SubscriptionSyncResult.skipped() =>
+      const SubscriptionSyncResult._(outcome: SubscriptionSyncOutcome.skipped);
+
+  factory SubscriptionSyncResult.error() =>
+      const SubscriptionSyncResult._(outcome: SubscriptionSyncOutcome.error);
+
+  @override
+  String toString() =>
+      'SubscriptionSyncResult(outcome: $outcome, restoredCount: $restoredCount)';
+}

--- a/lib/services/mixins/purchase_event_handler.dart
+++ b/lib/services/mixins/purchase_event_handler.dart
@@ -323,11 +323,7 @@ mixin PurchaseEventHandler on ServiceLogging {
           currentStatusResult.isSuccess &&
           currentStatusResult.value.expiryDate != null &&
           currentStatusResult.value.expiryDate!.isAfter(now)) {
-        final restoredPlan = PlanFactory.getPlanByProductId(
-          purchaseDetails.productID,
-        );
-        if (restoredPlan != null &&
-            restoredPlan.id == currentStatusResult.value.planId) {
+        if (plan.id == currentStatusResult.value.planId) {
           expiryDate = currentStatusResult.value.expiryDate!;
         } else {
           expiryDate = now.add(subscriptionDuration);

--- a/lib/services/mixins/purchase_event_handler.dart
+++ b/lib/services/mixins/purchase_event_handler.dart
@@ -316,13 +316,22 @@ mixin PurchaseEventHandler on ServiceLogging {
           ? currentStatusResult.value.lastResetDate
           : now;
 
-      // 復元時は既存の有効期限を維持（まだ有効であればそちらを使用）
+      // 復元時は既存の有効期限を維持（同じプランかつまだ有効であればそちらを使用）
+      // 異なるプランのrestoredや別sandboxアカウントの切替時は新規期限を算出する
       DateTime expiryDate;
       if (purchaseDetails.status == iap.PurchaseStatus.restored &&
           currentStatusResult.isSuccess &&
           currentStatusResult.value.expiryDate != null &&
           currentStatusResult.value.expiryDate!.isAfter(now)) {
-        expiryDate = currentStatusResult.value.expiryDate!;
+        final restoredPlan = PlanFactory.getPlanByProductId(
+          purchaseDetails.productID,
+        );
+        if (restoredPlan != null &&
+            restoredPlan.id == currentStatusResult.value.planId) {
+          expiryDate = currentStatusResult.value.expiryDate!;
+        } else {
+          expiryDate = now.add(subscriptionDuration);
+        }
       } else {
         expiryDate = now.add(subscriptionDuration);
       }

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -6,6 +6,7 @@ import 'interfaces/subscription_state_service_interface.dart';
 import 'interfaces/ai_usage_service_interface.dart';
 import 'interfaces/feature_access_service_interface.dart';
 import 'interfaces/in_app_purchase_service_interface.dart';
+import 'interfaces/subscription_sync_result.dart';
 
 /// SubscriptionService（Facade）
 ///
@@ -155,6 +156,10 @@ class SubscriptionService implements ISubscriptionService {
 
   @override
   Stream<PurchaseResult> get purchaseStream => _purchaseService.purchaseStream;
+
+  @override
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore() =>
+      _purchaseService.syncSubscriptionWithStore();
 
   @override
   Future<void> dispose() async {

--- a/lib/services/subscription_sync_delegate.dart
+++ b/lib/services/subscription_sync_delegate.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
+
+import '../constants/subscription_constants.dart';
+import '../core/result/result.dart';
+import '../models/subscription_status.dart';
+import 'interfaces/in_app_purchase_service_interface.dart';
+import 'interfaces/logging_service_interface.dart';
+import 'interfaces/subscription_state_service_interface.dart';
+import 'interfaces/subscription_sync_result.dart';
+import 'purchase_error_handler_mixin.dart';
+
+/// 起動時のApp Store購読状態同期を担当するデリゲート
+///
+/// ローカルがPremiumなのにStoreに有効購読が無い場合にBasicへ降格させる。
+/// ネットワークエラー時は誤Basic化を防ぐため現状維持する。
+class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
+  final ISubscriptionStateService Function() _getStateService;
+  final InAppPurchase? Function() _getInAppPurchase;
+  final Stream<PurchaseResult> _purchaseStream;
+  final ILoggingService? _loggingService;
+  final Duration _timeout;
+
+  SubscriptionSyncDelegate({
+    required ISubscriptionStateService Function() getStateService,
+    required InAppPurchase? Function() getInAppPurchase,
+    required Stream<PurchaseResult> purchaseStream,
+    ILoggingService? loggingService,
+    Duration timeout = SubscriptionConstants.storeSyncTimeout,
+  }) : _getStateService = getStateService,
+       _getInAppPurchase = getInAppPurchase,
+       _purchaseStream = purchaseStream,
+       _loggingService = loggingService,
+       _timeout = timeout;
+
+  @override
+  String get logTag => 'SubscriptionSyncDelegate';
+
+  @override
+  ILoggingService? get loggingService => _loggingService;
+
+  @override
+  ISubscriptionStateService getStateService() => _getStateService();
+
+  @override
+  InAppPurchase? getInAppPurchase() => _getInAppPurchase();
+
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore() async {
+    final validationError = validateBasePreconditions();
+    if (validationError != null) {
+      _loggingService?.warning(
+        'Store sync skipped: preconditions not met',
+        context: logTag,
+        data: validationError.message,
+      );
+      return Success(SubscriptionSyncResult.skipped());
+    }
+
+    final statusResult = await getStateService().getRawStatus();
+    if (statusResult.isFailure) {
+      _loggingService?.warning(
+        'Store sync skipped: failed to get current status',
+        context: logTag,
+      );
+      return Success(SubscriptionSyncResult.skipped());
+    }
+
+    final currentPlanId = statusResult.value.planId;
+    if (currentPlanId == SubscriptionConstants.basicPlanId) {
+      _loggingService?.debug(
+        'Store sync: already basic plan, no sync needed',
+        context: logTag,
+      );
+      return Success(SubscriptionSyncResult.noChange());
+    }
+
+    var restoredCount = 0;
+    var hasError = false;
+
+    final subscription = _purchaseStream.listen((result) {
+      if (result.status == PurchaseStatus.restored) {
+        restoredCount++;
+      } else if (result.status == PurchaseStatus.error ||
+          result.status == PurchaseStatus.networkError ||
+          result.status == PurchaseStatus.storeNotAvailable) {
+        hasError = true;
+      }
+    });
+
+    try {
+      await getInAppPurchase()!.restorePurchases();
+      await Future<void>.delayed(_timeout);
+    } catch (e) {
+      _loggingService?.error(
+        'Store sync: restorePurchases failed',
+        context: logTag,
+        error: e,
+      );
+      return Success(SubscriptionSyncResult.error());
+    } finally {
+      await subscription.cancel();
+    }
+
+    if (hasError) {
+      _loggingService?.warning(
+        'Store sync: error received, keeping current status',
+        context: logTag,
+      );
+      return Success(SubscriptionSyncResult.error());
+    }
+
+    if (restoredCount == 0) {
+      _loggingService?.info(
+        'Store sync: no valid subscriptions found, downgrading to Basic',
+        context: logTag,
+      );
+      final current = statusResult.value;
+      final downgradedStatus = SubscriptionStatus(
+        planId: SubscriptionConstants.basicPlanId,
+        isActive: true,
+        startDate: DateTime.now(),
+        monthlyUsageCount: current.monthlyUsageCount,
+        usageMonth: current.usageMonth,
+        lastResetDate: current.lastResetDate,
+        autoRenewal: false,
+      );
+      final saveResult = await getStateService().updateStatus(downgradedStatus);
+      if (saveResult.isFailure) {
+        _loggingService?.error(
+          'Store sync: failed to save downgraded status',
+          context: logTag,
+        );
+        return Success(SubscriptionSyncResult.error());
+      }
+      return Success(SubscriptionSyncResult.downgradedToBasic());
+    }
+
+    _loggingService?.info(
+      'Store sync: subscriptions found',
+      context: logTag,
+      data: {'restoredCount': restoredCount},
+    );
+    return Success(SubscriptionSyncResult.synced(restoredCount));
+  }
+}

--- a/test/mocks/mock_subscription_service.dart
+++ b/test/mocks/mock_subscription_service.dart
@@ -7,6 +7,7 @@ import 'package:smart_photo_diary/models/plans/premium_monthly_plan.dart';
 import 'package:smart_photo_diary/models/plans/premium_yearly_plan.dart';
 import 'package:smart_photo_diary/models/subscription_status.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/subscription_sync_result.dart';
 
 /// MockSubscriptionService
 ///
@@ -669,6 +670,11 @@ class MockSubscriptionService implements ISubscriptionService {
   @override
   Stream<PurchaseResult> get purchaseStream {
     return Stream.fromIterable(_purchaseUpdates);
+  }
+
+  @override
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore() async {
+    return Success(SubscriptionSyncResult.noChange());
   }
 
   @override

--- a/test/unit/services/interfaces/subscription_service_interface_test.dart
+++ b/test/unit/services/interfaces/subscription_service_interface_test.dart
@@ -8,6 +8,7 @@ import 'package:smart_photo_diary/models/plans/premium_monthly_plan.dart';
 import 'package:smart_photo_diary/models/plans/premium_yearly_plan.dart';
 import 'package:smart_photo_diary/models/subscription_status.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/subscription_sync_result.dart';
 
 // テスト用のモックサービス実装
 class MockSubscriptionService implements ISubscriptionService {
@@ -174,6 +175,11 @@ class MockSubscriptionService implements ISubscriptionService {
   @override
   Stream<PurchaseResult> get purchaseStream {
     return const Stream.empty();
+  }
+
+  @override
+  Future<Result<SubscriptionSyncResult>> syncSubscriptionWithStore() async {
+    return Success(SubscriptionSyncResult.noChange());
   }
 
   @override

--- a/test/unit/services/purchase_event_handler_test.dart
+++ b/test/unit/services/purchase_event_handler_test.dart
@@ -309,7 +309,7 @@ void main() {
       expect(updatedStatus.expiryDate!.isBefore(maxExpiry), isTrue);
     });
 
-    test('復元時に既存有効期限が未来 → 既存expiryDateが維持される', () async {
+    test('復元時に同プランかつ既存有効期限が未来 → 既存expiryDateが維持される', () async {
       final futureExpiry = DateTime.now().add(const Duration(days: 15));
       when(() => mockStateService.getCurrentStatus()).thenAnswer(
         (_) async => Success(
@@ -342,6 +342,46 @@ void main() {
       expect(
         updatedStatus.expiryDate!.millisecondsSinceEpoch,
         closeTo(futureExpiry.millisecondsSinceEpoch, 1000),
+      );
+    });
+
+    test('復元時に異プランかつ既存有効期限が未来 → 新しいexpiryDateが計算される', () async {
+      final futureExpiry = DateTime.now().add(const Duration(days: 15));
+      // ローカルは monthly、restoreは yearly（別アカウントやプラン変更シナリオ）
+      when(() => mockStateService.getCurrentStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: futureExpiry,
+          ),
+        ),
+      );
+      when(
+        () => mockStateService.updateStatus(any()),
+      ).thenAnswer((_) async => const Success(null));
+
+      final purchase = _TestPurchaseDetails(
+        productID: SubscriptionConstants.premiumYearlyProductId,
+        purchaseID: 'restore-txn',
+        transactionDate: DateTime.now().millisecondsSinceEpoch.toString(),
+        status: iap.PurchaseStatus.restored,
+        pendingCompletePurchase: false,
+      );
+
+      final before = DateTime.now();
+      await handler.applyPurchaseSideEffects(purchase);
+
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final updatedStatus = captured.first as SubscriptionStatus;
+
+      // 異プランのため既存期限は維持されず、yearly の新規期限（now+365日）が設定される
+      final minExpiry = before.add(const Duration(days: 365));
+      expect(
+        updatedStatus.expiryDate!.isAfter(minExpiry) ||
+            updatedStatus.expiryDate!.isAtSameMomentAs(minExpiry),
+        isTrue,
       );
     });
 

--- a/test/unit/services/subscription_sync_delegate_test.dart
+++ b/test/unit/services/subscription_sync_delegate_test.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
+import 'package:mocktail/mocktail.dart';
+import 'package:smart_photo_diary/constants/subscription_constants.dart';
+import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
+import 'package:smart_photo_diary/models/subscription_status.dart';
+import 'package:smart_photo_diary/services/interfaces/in_app_purchase_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/subscription_sync_result.dart';
+import 'package:smart_photo_diary/services/subscription_sync_delegate.dart';
+
+import '../../integration/mocks/mock_services.dart';
+
+class _MockSubscriptionStateService extends Mock
+    implements ISubscriptionStateService {}
+
+class _MockInAppPurchase extends Mock implements InAppPurchase {}
+
+void main() {
+  late _MockSubscriptionStateService mockStateService;
+  late _MockInAppPurchase mockIAP;
+  late MockILoggingService mockLogger;
+  late StreamController<PurchaseResult> purchaseStreamController;
+
+  // テスト用に短いタイムアウトを使用（実際の3秒を待たない）
+  const testTimeout = Duration(milliseconds: 50);
+
+  SubscriptionStatus buildStatus({
+    String planId = SubscriptionConstants.basicPlanId,
+    DateTime? expiryDate,
+  }) {
+    return SubscriptionStatus(
+      planId: planId,
+      isActive: planId != SubscriptionConstants.basicPlanId,
+      startDate: DateTime.now(),
+      expiryDate: expiryDate,
+      monthlyUsageCount: 0,
+      lastResetDate: DateTime.now(),
+      autoRenewal: expiryDate != null,
+    );
+  }
+
+  SubscriptionSyncDelegate buildDelegate({bool iapAvailable = true}) {
+    return SubscriptionSyncDelegate(
+      getStateService: () => mockStateService,
+      getInAppPurchase: () => iapAvailable ? mockIAP : null,
+      purchaseStream: purchaseStreamController.stream,
+      loggingService: mockLogger,
+      timeout: testTimeout,
+    );
+  }
+
+  setUpAll(() {
+    registerMockFallbacks();
+    registerFallbackValue(
+      SubscriptionStatus(
+        planId: 'basic',
+        isActive: false,
+        startDate: DateTime.now(),
+        monthlyUsageCount: 0,
+        autoRenewal: false,
+      ),
+    );
+  });
+
+  setUp(() {
+    mockStateService = _MockSubscriptionStateService();
+    mockIAP = _MockInAppPurchase();
+    mockLogger = TestServiceSetup.getLoggingService();
+    purchaseStreamController = StreamController<PurchaseResult>.broadcast(
+      sync: true,
+    );
+
+    when(() => mockStateService.isInitialized).thenReturn(true);
+    when(() => mockIAP.restorePurchases()).thenAnswer((_) async {});
+    when(
+      () => mockStateService.updateStatus(any()),
+    ).thenAnswer((_) async => const Success(null));
+  });
+
+  tearDown(() async {
+    await purchaseStreamController.close();
+    TestServiceSetup.clearAllMocks();
+  });
+
+  group('syncSubscriptionWithStore', () {
+    test('IAP未初期化 → skipped を返し状態変更しない', () async {
+      final delegate = buildDelegate(iapAvailable: false);
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.skipped);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('stateService未初期化 → skipped を返し状態変更しない', () async {
+      when(() => mockStateService.isInitialized).thenReturn(false);
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.skipped);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('ローカルがBasic → noChange を返し状態変更しない', () async {
+      when(
+        () => mockStateService.getRawStatus(),
+      ).thenAnswer((_) async => Success(buildStatus()));
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.noChange);
+      verifyNever(() => mockIAP.restorePurchases());
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('ローカルがPremium、restoredゼロ、エラーなし → Basic に降格', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
+      verify(() => mockStateService.updateStatus(any())).called(1);
+    });
+
+    test('ローカルがPremium、restored 1件 → synced(1) を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+        purchaseStreamController.add(
+          const PurchaseResult(
+            status: PurchaseStatus.restored,
+            productId: SubscriptionConstants.premiumMonthlyProductId,
+          ),
+        );
+      });
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+      expect(result.value.restoredCount, 1);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('ローカルがPremium、error イベントあり → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+        purchaseStreamController.add(
+          const PurchaseResult(
+            status: PurchaseStatus.error,
+            errorMessage: 'network error',
+          ),
+        );
+      });
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('restorePurchases() が例外スロー → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(
+        () => mockIAP.restorePurchases(),
+      ).thenThrow(const ServiceException('Store unavailable'));
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('getRawStatus 失敗 → skipped を返し状態変更しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => const Failure(ServiceException('Hive read error')),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.skipped);
+      verifyNever(() => mockIAP.restorePurchases());
+    });
+
+    test('ローカルがPremium、storeNotAvailable イベント → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+        purchaseStreamController.add(
+          const PurchaseResult(status: PurchaseStatus.storeNotAvailable),
+        );
+      });
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('ローカルがPremium、降格時に既存monthlyUsageCountが保持される', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ).copyWith(monthlyUsageCount: 7),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      expect(saved.planId, SubscriptionConstants.basicPlanId);
+      expect(saved.isActive, isTrue);
+      expect(saved.expiryDate, isNull);
+      expect(saved.monthlyUsageCount, 7);
+    });
+
+    test('ローカルがPremium、降格時updateStatus失敗 → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockStateService.updateStatus(any())).thenAnswer(
+        (_) async => const Failure(ServiceException('Hive write error')),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+    });
+
+    test('ローカルがPremium、タイムアウト後に restored が来ても集計されず降格', () async {
+      // タイムアウトを極短に設定し、delayed で遅延して emit しても間に合わないことを確認
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+        // testTimeout (50ms) より長い遅延で emit → 集計されない
+        Future<void>.delayed(const Duration(milliseconds: 200)).then((_) {
+          if (!purchaseStreamController.isClosed) {
+            purchaseStreamController.add(
+              const PurchaseResult(
+                status: PurchaseStatus.restored,
+                productId: SubscriptionConstants.premiumMonthlyProductId,
+              ),
+            );
+          }
+        });
+      });
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `SubscriptionSyncDelegate` that calls `restorePurchases()` on startup and downgrades local Premium state to Basic when no valid subscriptions are found in the Store
- Restricts expiry-date preservation on restore to same-plan only, preventing stale expiry carry-over when a different-plan subscription is restored
- Preserves `monthlyUsageCount` / `usageMonth` / `lastResetDate` on downgrade so the user's free-tier usage history is not reset
- Handles `updateStatus` write failure by returning `error` instead of falsely reporting `downgradedToBasic`
- Uses `try/finally` to guarantee stream listener cancellation even on exception or app suspension
- Wires up the sync as fire-and-forget in `main.dart` (does not block app startup)
- Adds 12 unit tests covering all sync outcomes

## Test Plan

- `fvm flutter test` → 2041 tests, all passed
- `fvm flutter analyze` → No issues found
- iOS sandbox E2E:
  1. Sign in as sandbox account A, purchase Premium monthly → close app
  2. Switch to sandbox account B (no purchases) in iOS Settings → App Store → Sandbox Account
  3. Launch app, wait 3–5 seconds
  4. Confirm Settings screen shows "Basic"
  5. Confirm log output: `Store sync: no valid subscriptions found, downgrading to Basic`
  6. Switch back to account A → launch app → confirm Premium is restored (`synced(1)`)
  7. Airplane mode + account B → confirm no false downgrade (`error`/`skipped` keeps current state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 起動時にApp Storeとの購読状態を自動同期する機能を追加。Premium/Basicの購読ステータスの整合性が確保されます。

* **Bug Fixes**
  * 購入復元時の有効期限計算ロジックを改善。プラン切り替え時に正確な有効期限が計算されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->