### PR TITLE
fix: prevent syncSubscriptionWithStore from overwriting state during restore

### DIFF
--- a/lib/services/in_app_purchase_service.dart
+++ b/lib/services/in_app_purchase_service.dart
@@ -48,11 +48,19 @@ class InAppPurchaseService
   @override
   set isPurchasing(bool value) => _isPurchasing = value;
 
+  // 参照カウント: true で ++, false で -- (0以下にはならない)
+  // 複数の sync が重なっても最後の finally が false を流すまでガードが外れない。
   @override
-  bool get isSyncing => _isSyncing;
+  bool get isSyncing => _syncRefCount > 0;
 
   @override
-  set isSyncing(bool value) => _isSyncing = value;
+  set isSyncing(bool value) {
+    if (value) {
+      _syncRefCount++;
+    } else if (_syncRefCount > 0) {
+      _syncRefCount--;
+    }
+  }
 
   // In-App Purchase関連
   InAppPurchase? _inAppPurchase;
@@ -65,8 +73,8 @@ class InAppPurchaseService
   // 購入処理中フラグ
   bool _isPurchasing = false;
 
-  // Store同期中フラグ（同期中は restored イベントで状態を更新しない）
-  bool _isSyncing = false;
+  // Store同期中参照カウント（0 より大きければ isSyncing = true）
+  int _syncRefCount = 0;
 
   // デリゲート
   late final PurchaseProductDelegate _productDelegate;

--- a/lib/services/in_app_purchase_service.dart
+++ b/lib/services/in_app_purchase_service.dart
@@ -48,6 +48,12 @@ class InAppPurchaseService
   @override
   set isPurchasing(bool value) => _isPurchasing = value;
 
+  @override
+  bool get isSyncing => _isSyncing;
+
+  @override
+  set isSyncing(bool value) => _isSyncing = value;
+
   // In-App Purchase関連
   InAppPurchase? _inAppPurchase;
   StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
@@ -58,6 +64,9 @@ class InAppPurchaseService
 
   // 購入処理中フラグ
   bool _isPurchasing = false;
+
+  // Store同期中フラグ（同期中は restored イベントで状態を更新しない）
+  bool _isSyncing = false;
 
   // デリゲート
   late final PurchaseProductDelegate _productDelegate;
@@ -87,6 +96,7 @@ class InAppPurchaseService
       getInAppPurchase: () => _inAppPurchase,
       purchaseStream: _purchaseStreamController.stream,
       loggingService: _loggingService,
+      onSyncStateChanged: (syncing) => isSyncing = syncing,
     );
   }
 

--- a/lib/services/mixins/purchase_event_handler.dart
+++ b/lib/services/mixins/purchase_event_handler.dart
@@ -38,6 +38,10 @@ mixin PurchaseEventHandler on ServiceLogging {
   bool get isPurchasing;
   set isPurchasing(bool value);
 
+  /// Store同期中フラグ — true の間は restored イベントで状態を更新しない
+  bool get isSyncing;
+  set isSyncing(bool value);
+
   /// 購入ストリーム更新ハンドラ
   Future<void> onPurchaseUpdated(
     List<iap.PurchaseDetails> purchaseDetailsList,
@@ -190,8 +194,23 @@ mixin PurchaseEventHandler on ServiceLogging {
         data: {'productId': purchaseDetails.productID},
       );
 
-      // サイドエフェクトのみ実行（ストリームイベントはemitしない）
-      final plan = await applyPurchaseSideEffects(purchaseDetails);
+      final plan = PlanFactory.getPlanByProductId(purchaseDetails.productID);
+      if (plan == null) {
+        purchaseStreamController.add(
+          PurchaseResult(
+            status: iapsi.PurchaseStatus.error,
+            productId: purchaseDetails.productID,
+            errorMessage: 'Unknown product ID: ${purchaseDetails.productID}',
+          ),
+        );
+        return;
+      }
+
+      // Store同期中: 存在確認のみ行い状態を更新しない。
+      // 同期デリゲートが restored カウントを取得できるようストリームには流す。
+      if (!isSyncing) {
+        await updateSubscriptionFromPurchase(purchaseDetails, plan);
+      }
 
       final result = PurchaseResult(
         status: iapsi.PurchaseStatus.restored,

--- a/lib/services/mixins/purchase_event_handler.dart
+++ b/lib/services/mixins/purchase_event_handler.dart
@@ -196,6 +196,7 @@ mixin PurchaseEventHandler on ServiceLogging {
 
       final plan = PlanFactory.getPlanByProductId(purchaseDetails.productID);
       if (plan == null) {
+        isPurchasing = false;
         purchaseStreamController.add(
           PurchaseResult(
             status: iapsi.PurchaseStatus.error,

--- a/lib/services/subscription_sync_delegate.dart
+++ b/lib/services/subscription_sync_delegate.dart
@@ -4,6 +4,7 @@ import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
 
 import '../constants/subscription_constants.dart';
 import '../core/result/result.dart';
+import '../models/plans/plan_factory.dart';
 import '../models/subscription_status.dart';
 import 'interfaces/in_app_purchase_service_interface.dart';
 import 'interfaces/logging_service_interface.dart';
@@ -22,17 +23,22 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
   final ILoggingService? _loggingService;
   final Duration _timeout;
 
+  /// sync中フラグの制御コールバック — PurchaseEventHandler 側の isSyncing を操作する
+  final void Function(bool)? _onSyncStateChanged;
+
   SubscriptionSyncDelegate({
     required ISubscriptionStateService Function() getStateService,
     required InAppPurchase? Function() getInAppPurchase,
     required Stream<PurchaseResult> purchaseStream,
     ILoggingService? loggingService,
     Duration timeout = SubscriptionConstants.storeSyncTimeout,
+    void Function(bool)? onSyncStateChanged,
   }) : _getStateService = getStateService,
        _getInAppPurchase = getInAppPurchase,
        _purchaseStream = purchaseStream,
        _loggingService = loggingService,
-       _timeout = timeout;
+       _timeout = timeout,
+       _onSyncStateChanged = onSyncStateChanged;
 
   @override
   String get logTag => 'SubscriptionSyncDelegate';
@@ -76,11 +82,13 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
     }
 
     var restoredCount = 0;
+    String? restoredProductId;
     var hasError = false;
 
     final subscription = _purchaseStream.listen((result) {
       if (result.status == PurchaseStatus.restored) {
         restoredCount++;
+        restoredProductId = result.productId;
       } else if (result.status == PurchaseStatus.error ||
           result.status == PurchaseStatus.networkError ||
           result.status == PurchaseStatus.storeNotAvailable) {
@@ -88,6 +96,7 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       }
     });
 
+    _onSyncStateChanged?.call(true);
     try {
       await getInAppPurchase()!.restorePurchases();
       await Future<void>.delayed(_timeout);
@@ -100,6 +109,7 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       return Success(SubscriptionSyncResult.error());
     } finally {
       await subscription.cancel();
+      _onSyncStateChanged?.call(false);
     }
 
     if (hasError) {
@@ -141,6 +151,51 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       context: logTag,
       data: {'restoredCount': restoredCount},
     );
+
+    // ローカルの expiryDate が切れている（または未設定）か、Store 側でプランが
+    // 変更されている場合に更新する。
+    // in_app_purchase は自動更新に対して purchased イベントを発火しないため、
+    // 起動時同期がローカル期限を最新に保つ唯一の手段になる。
+    // プラン変更（月額→年額など）は期限が有効中でも即座に反映する。
+    final current = statusResult.value;
+    final now = DateTime.now();
+    final activePlan = PlanFactory.getPlanByProductId(restoredProductId ?? '');
+    final activePlanId = activePlan?.id ?? current.planId;
+    final isExpiryStale =
+        current.expiryDate == null || current.expiryDate!.isBefore(now);
+    final isPlanChanged = activePlanId != current.planId;
+
+    if (isExpiryStale || isPlanChanged) {
+      final duration = Duration(
+        days: (activePlan?.isYearly ?? false)
+            ? SubscriptionConstants.subscriptionYearDays
+            : SubscriptionConstants.subscriptionMonthDays,
+      );
+      final refreshed = current.copyWith(
+        planId: activePlanId,
+        expiryDate: now.add(duration),
+        autoRenewal: true,
+      );
+      final saveResult = await getStateService().updateStatus(refreshed);
+      if (saveResult.isFailure) {
+        _loggingService?.warning(
+          'Store sync: failed to refresh subscription state',
+          context: logTag,
+        );
+        return Success(SubscriptionSyncResult.error());
+      } else {
+        _loggingService?.info(
+          'Store sync: refreshed subscription state',
+          context: logTag,
+          data: {
+            'planId': activePlanId,
+            'planChanged': isPlanChanged,
+            'expiryRefreshed': isExpiryStale,
+          },
+        );
+      }
+    }
+
     return Success(SubscriptionSyncResult.synced(restoredCount));
   }
 }

--- a/lib/services/subscription_sync_delegate.dart
+++ b/lib/services/subscription_sync_delegate.dart
@@ -82,13 +82,14 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
     }
 
     var restoredCount = 0;
-    String? restoredProductId;
+    final restoredProductIds = <String>{};
     var hasError = false;
 
     final subscription = _purchaseStream.listen((result) {
       if (result.status == PurchaseStatus.restored) {
         restoredCount++;
-        restoredProductId = result.productId;
+        final productId = result.productId;
+        if (productId != null) restoredProductIds.add(productId);
       } else if (result.status == PurchaseStatus.error ||
           result.status == PurchaseStatus.networkError ||
           result.status == PurchaseStatus.storeNotAvailable) {
@@ -152,6 +153,17 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       data: {'restoredCount': restoredCount},
     );
 
+    // 複数の distinct productId が restored された場合、どちらが現在アクティブかを
+    // イベント配信順に依存せず決定できないため、自動 refresh はスキップする。
+    if (restoredProductIds.length > 1) {
+      _loggingService?.warning(
+        'Store sync: multiple distinct product IDs restored, skipping auto-refresh',
+        context: logTag,
+        data: {'productIds': restoredProductIds.join(',')},
+      );
+      return Success(SubscriptionSyncResult.synced(restoredCount));
+    }
+
     // ローカルの expiryDate が切れている（または未設定）か、Store 側でプランが
     // 変更されている場合に更新する。
     // in_app_purchase は自動更新に対して purchased イベントを発火しないため、
@@ -159,6 +171,9 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
     // プラン変更（月額→年額など）は期限が有効中でも即座に反映する。
     final current = statusResult.value;
     final now = DateTime.now();
+    final restoredProductId = restoredProductIds.isEmpty
+        ? null
+        : restoredProductIds.first;
     final activePlan = PlanFactory.getPlanByProductId(restoredProductId ?? '');
     final activePlanId = activePlan?.id ?? current.planId;
     final isExpiryStale =

--- a/test/unit/services/purchase_event_handler_test.dart
+++ b/test/unit/services/purchase_event_handler_test.dart
@@ -66,6 +66,9 @@ class _TestEventHandler with ServiceLogging, PurchaseEventHandler {
   bool isPurchasing = false;
 
   @override
+  bool isSyncing = false;
+
+  @override
   iap.InAppPurchase? get inAppPurchaseInstance => null;
 
   @override
@@ -546,6 +549,64 @@ void main() {
       await handler.handlePurchaseRestored(purchase);
 
       expect(handler.isPurchasing, isFalse);
+    });
+  });
+
+  group('isSyncing フラグ — Store同期中の副作用ガード', () {
+    setUp(() {
+      when(() => mockStateService.getCurrentStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(
+        () => mockStateService.updateStatus(any()),
+      ).thenAnswer((_) async => const Success(null));
+    });
+
+    test('isSyncing=true のとき handlePurchaseRestored は状態を更新しない', () async {
+      handler.isSyncing = true;
+      final purchase = makePurchase(
+        productId: SubscriptionConstants.premiumMonthlyProductId,
+        status: iap.PurchaseStatus.restored,
+      );
+
+      await handler.handlePurchaseRestored(purchase);
+
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test(
+      'isSyncing=true のとき handlePurchaseRestored は restored をストリームに流す',
+      () async {
+        handler.isSyncing = true;
+        final purchase = makePurchase(
+          productId: SubscriptionConstants.premiumMonthlyProductId,
+          status: iap.PurchaseStatus.restored,
+        );
+
+        PurchaseResult? emitted;
+        streamController.stream.listen((r) => emitted = r);
+
+        await handler.handlePurchaseRestored(purchase);
+
+        expect(emitted?.status, PurchaseStatus.restored);
+      },
+    );
+
+    test('isSyncing=false のとき handlePurchaseRestored は通常通り状態を更新する', () async {
+      handler.isSyncing = false;
+      final purchase = makePurchase(
+        productId: SubscriptionConstants.premiumMonthlyProductId,
+        status: iap.PurchaseStatus.restored,
+      );
+
+      await handler.handlePurchaseRestored(purchase);
+
+      verify(() => mockStateService.updateStatus(any())).called(1);
     });
   });
 }

--- a/test/unit/services/purchase_event_handler_test.dart
+++ b/test/unit/services/purchase_event_handler_test.dart
@@ -550,6 +550,21 @@ void main() {
 
       expect(handler.isPurchasing, isFalse);
     });
+
+    test(
+      'handlePurchaseRestored: 未知productId → isPurchasingがfalseにリセットされる',
+      () async {
+        handler.isPurchasing = true;
+        final purchase = makePurchase(
+          productId: 'unknown.product.id',
+          status: iap.PurchaseStatus.restored,
+        );
+
+        await handler.handlePurchaseRestored(purchase);
+
+        expect(handler.isPurchasing, isFalse);
+      },
+    );
   });
 
   group('isSyncing フラグ — Store同期中の副作用ガード', () {

--- a/test/unit/services/subscription_sync_delegate_test.dart
+++ b/test/unit/services/subscription_sync_delegate_test.dart
@@ -596,6 +596,42 @@ void main() {
       expect(calls, [true, false]);
     });
 
+    test(
+      '月額・年額の両 productId が restored された場合 → auto-refreshスキップしてsynced(2)を返す',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumMonthlyPlanId,
+              expiryDate: DateTime.now().add(const Duration(days: 15)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumYearlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        expect(result.value.restoredCount, 2);
+        verifyNever(() => mockStateService.updateStatus(any()));
+      },
+    );
+
     test('ローカルがPremium、タイムアウト後に restored が来ても集計されず降格', () async {
       // タイムアウトを極短に設定し、delayed で遅延して emit しても間に合わないことを確認
       when(() => mockStateService.getRawStatus()).thenAnswer(

--- a/test/unit/services/subscription_sync_delegate_test.dart
+++ b/test/unit/services/subscription_sync_delegate_test.dart
@@ -43,13 +43,17 @@ void main() {
     );
   }
 
-  SubscriptionSyncDelegate buildDelegate({bool iapAvailable = true}) {
+  SubscriptionSyncDelegate buildDelegate({
+    bool iapAvailable = true,
+    void Function(bool)? onSyncStateChanged,
+  }) {
     return SubscriptionSyncDelegate(
       getStateService: () => mockStateService,
       getInAppPurchase: () => iapAvailable ? mockIAP : null,
       purchaseStream: purchaseStreamController.stream,
       loggingService: mockLogger,
       timeout: testTimeout,
+      onSyncStateChanged: onSyncStateChanged,
     );
   }
 
@@ -140,12 +144,240 @@ void main() {
       verify(() => mockStateService.updateStatus(any())).called(1);
     });
 
-    test('ローカルがPremium、restored 1件 → synced(1) を返し降格しない', () async {
+    test(
+      'ローカルがPremium、restored 1件、expiryDate未来 → synced(1)、updateStatus呼ばれない',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumMonthlyPlanId,
+              expiryDate: DateTime.now().add(const Duration(days: 15)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        expect(result.value.restoredCount, 1);
+        verifyNever(() => mockStateService.updateStatus(any()));
+      },
+    );
+
+    test(
+      'ローカルが月額Premium、restored が年額productId、expiryDate未来 → planId更新・365日期限でリフレッシュ',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumMonthlyPlanId,
+              expiryDate: DateTime.now().add(const Duration(days: 15)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumYearlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+        final before = DateTime.now();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        expect(saved.planId, SubscriptionConstants.premiumYearlyPlanId);
+        final expectedExpiry = before.add(
+          const Duration(days: SubscriptionConstants.subscriptionYearDays),
+        );
+        expect(
+          saved.expiryDate!.isAfter(
+            expectedExpiry.subtract(const Duration(seconds: 1)),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'ローカルが年額Premium、restored が月額productId、expiryDate未来 → planId更新・30日期限でリフレッシュ',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumYearlyPlanId,
+              expiryDate: DateTime.now().add(const Duration(days: 300)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+        final before = DateTime.now();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
+        final expectedExpiry = before.add(
+          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
+        );
+        expect(
+          saved.expiryDate!.isAfter(
+            expectedExpiry.subtract(const Duration(seconds: 1)),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'ローカルがPremium、restored 1件、expiryDate過去 → expiryDate更新してsynced',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumMonthlyPlanId,
+              expiryDate: DateTime.now().subtract(const Duration(days: 1)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
+        expect(saved.expiryDate, isNotNull);
+        expect(saved.expiryDate!.isAfter(DateTime.now()), isTrue);
+      },
+    );
+
+    test(
+      'ローカルがPremium月額、restored 1件、expiryDate null → 30日の期限でリフレッシュ',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(planId: SubscriptionConstants.premiumMonthlyPlanId),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+        final before = DateTime.now();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        final expectedExpiry = before.add(
+          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
+        );
+        expect(
+          saved.expiryDate!.isAfter(
+            expectedExpiry.subtract(const Duration(seconds: 1)),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('ローカルがPremium年額、restored 1件、expiryDate過去 → 365日の期限でリフレッシュ', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumYearlyPlanId,
+            expiryDate: DateTime.now().subtract(const Duration(days: 1)),
+          ),
+        ),
+      );
+      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+        purchaseStreamController.add(
+          const PurchaseResult(
+            status: PurchaseStatus.restored,
+            productId: SubscriptionConstants.premiumYearlyProductId,
+          ),
+        );
+      });
+      final delegate = buildDelegate();
+      final before = DateTime.now();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      final expectedExpiry = before.add(
+        const Duration(days: SubscriptionConstants.subscriptionYearDays),
+      );
+      expect(
+        saved.expiryDate!.isAfter(
+          expectedExpiry.subtract(const Duration(seconds: 1)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('restored 1件、expiryDate過去、updateStatus失敗 → error を返す', () async {
       when(() => mockStateService.getRawStatus()).thenAnswer(
         (_) async => Success(
           buildStatus(
             planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
+            expiryDate: DateTime.now().subtract(const Duration(days: 1)),
           ),
         ),
       );
@@ -157,15 +389,67 @@ void main() {
           ),
         );
       });
+      when(
+        () => mockStateService.updateStatus(any()),
+      ).thenAnswer((_) async => const Failure(ServiceException('write error')));
       final delegate = buildDelegate();
 
       final result = await delegate.syncSubscriptionWithStore();
 
       expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-      expect(result.value.restoredCount, 1);
-      verifyNever(() => mockStateService.updateStatus(any()));
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
     });
+
+    test(
+      'ローカルが年額Premium、restored が月額productId、expiryDate過去 → 月額30日・planIdも月額に更新',
+      () async {
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumYearlyPlanId,
+              expiryDate: DateTime.now().subtract(const Duration(days: 1)),
+            ),
+          ),
+        );
+        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
+          purchaseStreamController.add(
+            const PurchaseResult(
+              status: PurchaseStatus.restored,
+              productId: SubscriptionConstants.premiumMonthlyProductId,
+            ),
+          );
+        });
+        final delegate = buildDelegate();
+        final before = DateTime.now();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
+        final expectedExpiry = before.add(
+          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
+        );
+        expect(
+          saved.expiryDate!.isAfter(
+            expectedExpiry.subtract(const Duration(seconds: 1)),
+          ),
+          isTrue,
+        );
+        expect(
+          saved.expiryDate!.isBefore(
+            before.add(
+              const Duration(days: SubscriptionConstants.subscriptionYearDays),
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('ローカルがPremium、error イベントあり → error を返し降格しない', () async {
       when(() => mockStateService.getRawStatus()).thenAnswer(
@@ -293,6 +577,23 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.value.outcome, SubscriptionSyncOutcome.error);
+    });
+
+    test('onSyncStateChanged: sync開始時にtrue、終了時にfalseが呼ばれる', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      final calls = <bool>[];
+      final delegate = buildDelegate(onSyncStateChanged: calls.add);
+
+      await delegate.syncSubscriptionWithStore();
+
+      expect(calls, [true, false]);
     });
 
     test('ローカルがPremium、タイムアウト後に restored が来ても集計されず降格', () async {


### PR DESCRIPTION
## Summary

- Introduces `isSyncing` flag in `PurchaseEventHandler` mixin so that `restorePurchases()` events do not trigger `applyPurchaseSideEffects` during startup sync — this was the root cause of sandbox purchase history clear not removing Premium state
- `SubscriptionSyncDelegate` now handles its own state refresh after sync completes:
  - Refreshes stale `expiryDate` when Store confirms an active subscription
  - Reflects plan changes (e.g. monthly→yearly) even when local expiry is still valid, using `PlanFactory.getPlanByProductId` to resolve productId→planId
  - Returns `error` (not `synced`) when the refresh save fails, matching the downgrade-failure behavior
- `onSyncStateChanged` callback wires the delegate's sync state into `InAppPurchaseService._isSyncing`

## Test Plan

- `test/unit/services/purchase_event_handler_test.dart` — added 3 tests for `isSyncing` guard (blocks state update, still emits to stream, unblocks when false)
- `test/unit/services/subscription_sync_delegate_test.dart` — added tests for: same-plan valid expiry (no update), monthly→yearly upgrade with valid expiry, yearly→monthly with valid expiry, expiry refresh failure returns error
- All 20 sync delegate tests and full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 購読管理のストア同期処理を改善し、復元時の状態管理を最適化しました

* **Tests**
  * 購読同期の複数シナリオに対するテストカバレッジを拡張しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->