### PR TITLE
fix: determine subscription downgrade from StoreKit2 entitlement

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		7EBE120D2FCBA8B0001BD379 /* StoreKit2EntitlementHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBE120C2FCBA8B0001BD379 /* StoreKit2EntitlementHandler.swift */; };
 		7EA292832E22155B003E54D4 /* SmartPhotoDiary.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 7EA292822E22155B003E54D4 /* SmartPhotoDiary.storekit */; };
 		7EA292852E22157A003E54D4 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EA292842E22157A003E54D4 /* StoreKit.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -55,6 +56,7 @@
 		74790927AECCCA56B758EDAF /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7EBE120C2FCBA8B0001BD379 /* StoreKit2EntitlementHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2EntitlementHandler.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7E7A7DC82F66B8A2002F1131 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
 		7E7A7DC92F66B8A2002F1131 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				7EBE120C2FCBA8B0001BD379 /* StoreKit2EntitlementHandler.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -388,6 +391,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				7EBE120D2FCBA8B0001BD379 /* StoreKit2EntitlementHandler.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,5 +12,10 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    if let registrar = engineBridge.pluginRegistry.registrar(
+      forPlugin: "StoreKit2EntitlementHandler"
+    ) {
+      StoreKit2EntitlementHandler.register(with: registrar)
+    }
   }
 }

--- a/ios/Runner/StoreKit2EntitlementHandler.swift
+++ b/ios/Runner/StoreKit2EntitlementHandler.swift
@@ -1,0 +1,99 @@
+import Flutter
+import StoreKit
+
+/// StoreKit2 を用いて現在有効なサブスクリプションの実有効期限を返すハンドラ。
+///
+/// in_app_purchase プラグインは Apple が管理する本当の expirationDate を公開しない。
+/// 失効・解約・返金（revocation）の正確な判定には、このチャネル経由で StoreKit2 の
+/// Transaction.currentEntitlements を直接参照する必要がある。
+///
+/// デプロイターゲットは iOS 16.4+ のため StoreKit2 API は常に利用可能（@available 不要）。
+final class StoreKit2EntitlementHandler {
+  static let channelName = "smart_photo_diary/storekit2"
+
+  static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: registrar.messenger()
+    )
+    let instance = StoreKit2EntitlementHandler()
+    channel.setMethodCallHandler { call, result in
+      instance.handle(call, result: result)
+    }
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "getActiveSubscription":
+      let args = call.arguments as? [String: Any]
+      let productIds = args?["productIds"] as? [String] ?? []
+      Task {
+        let entitlement = await Self.activeSubscription(productIds: Set(productIds))
+        // FlutterResult はプラットフォーム（メイン）スレッドで返す
+        await MainActor.run { result(entitlement) }
+      }
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  /// 指定 productId 群のうち、現在有効な自動更新購読を1件返す。
+  ///
+  /// - 有効な購読が無い（失効・解約・未購入）: nil
+  /// - 複数有効: expirationDate が最も先のものを採用（月→年アップグレード直後など）
+  private static func activeSubscription(productIds: Set<String>) async -> [String: Any]? {
+    var best: (productId: String, expiry: Date)?
+
+    for await verificationResult in Transaction.currentEntitlements {
+      guard case .verified(let transaction) = verificationResult else { continue }
+      guard transaction.productType == .autoRenewable else { continue }
+      guard productIds.isEmpty || productIds.contains(transaction.productID) else { continue }
+      guard transaction.revocationDate == nil else { continue }
+      guard let expiry = transaction.expirationDate, expiry > Date() else { continue }
+
+      if best == nil || expiry > best!.expiry {
+        best = (transaction.productID, expiry)
+      }
+    }
+
+    guard let best else { return nil }
+
+    var payload: [String: Any] = [
+      "productId": best.productId,
+      "expiryDateMs": Int(best.expiry.timeIntervalSince1970 * 1000),
+    ]
+    // 取得不能時はキーを省略し、Dart 側で既存値を保持する（キャンセル状態の誤上書き防止）。
+    if let willAutoRenew = await Self.willAutoRenew(for: best.productId) {
+      payload["willAutoRenew"] = willAutoRenew
+    }
+    return payload
+  }
+
+  /// 指定商品の自動更新意思 (willAutoRenew) を返す。取得できない場合は nil。
+  ///
+  /// ユーザーが解約しても有効期限までは currentEntitlements に残るため、
+  /// この値を見ないと「解約済みだが期限内」の状態を判別できない。
+  private static func willAutoRenew(for productId: String) async -> Bool? {
+    do {
+      let products = try await Product.products(for: [productId])
+      guard let subscription = products.first?.subscription else { return nil }
+      let statuses = try await subscription.status
+
+      for status in statuses {
+        guard case .verified(let renewalInfo) = status.renewalInfo else { continue }
+        if renewalInfo.currentProductID == productId {
+          return renewalInfo.willAutoRenew
+        }
+      }
+      // 対象商品に一致しない場合のフォールバック（同一サブスクグループ内のプラン変更時など）
+      for status in statuses {
+        if case .verified(let renewalInfo) = status.renewalInfo {
+          return renewalInfo.willAutoRenew
+        }
+      }
+      return nil
+    } catch {
+      return nil
+    }
+  }
+}

--- a/lib/constants/subscription_constants.dart
+++ b/lib/constants/subscription_constants.dart
@@ -59,13 +59,6 @@ class SubscriptionConstants {
   /// サブスクリプション状態管理用のHiveボックス名
   static const String hiveBoxName = 'subscription_box';
 
-  // ========================================
-  // Store同期設定
-  // ========================================
-
-  /// 起動時Store同期のタイムアウト（restorePurchasesの結果待ち時間）
-  static const Duration storeSyncTimeout = Duration(seconds: 3);
-
   /// サブスクリプション状態のキー
   static const String statusKey = 'subscription_status';
 

--- a/lib/core/service_registration.dart
+++ b/lib/core/service_registration.dart
@@ -26,7 +26,9 @@ import '../services/storage_service.dart';
 import '../services/interfaces/storage_service_interface.dart';
 import '../services/interfaces/subscription_service_interface.dart';
 import '../services/subscription_service.dart';
+import '../services/interfaces/store_entitlement_service_interface.dart';
 import '../services/interfaces/subscription_state_service_interface.dart';
+import '../services/store_entitlement_service.dart';
 import '../services/subscription_state_service.dart';
 import '../services/interfaces/ai_usage_service_interface.dart';
 import '../services/ai_usage_service.dart';
@@ -178,6 +180,11 @@ class ServiceRegistration {
       context: 'ServiceRegistration._registerCoreServices',
     );
 
+    // 1.5 StoreEntitlementService (StoreKit2 実有効期限取得、loggerのみ依存)
+    serviceLocator.registerSingleton<IStoreEntitlementService>(
+      StoreEntitlementService(logger: loggingService),
+    );
+
     // 2. SubscriptionStateService (Hive依存のみ、基盤サブスクリプション状態管理)
     serviceLocator.registerAsyncFactory<ISubscriptionStateService>(() async {
       final service = SubscriptionStateService(logger: loggingService);
@@ -208,6 +215,7 @@ class ServiceRegistration {
           .getAsync<ISubscriptionStateService>();
       final service = InAppPurchaseService(
         stateService: stateService,
+        entitlementService: serviceLocator.get<IStoreEntitlementService>(),
         logger: loggingService,
       );
       await service.initialize();

--- a/lib/models/store_entitlement.dart
+++ b/lib/models/store_entitlement.dart
@@ -1,0 +1,36 @@
+/// StoreKit2 から取得した、現在有効な自動更新サブスクリプションのエンタイトルメント。
+///
+/// in_app_purchase プラグインが公開しない Apple 管理の実有効期限 ([expiryDate]) を保持する。
+class StoreEntitlement {
+  /// 有効な購読の商品ID（例: smart_photo_diary_premium_monthly_plan）
+  final String productId;
+
+  /// Apple が管理する実際の有効期限
+  final DateTime expiryDate;
+
+  /// Apple が返す自動更新の意思。ネイティブ側で取得できなかった場合は null。
+  /// （解約済みだが期限内の購読を判別するために使用）
+  final bool? willAutoRenew;
+
+  const StoreEntitlement({
+    required this.productId,
+    required this.expiryDate,
+    this.willAutoRenew,
+  });
+
+  /// ネイティブ MethodChannel の戻り値（Map）からインスタンスを生成する。
+  factory StoreEntitlement.fromMap(Map<dynamic, dynamic> map) {
+    return StoreEntitlement(
+      productId: map['productId'] as String,
+      expiryDate: DateTime.fromMillisecondsSinceEpoch(
+        map['expiryDateMs'] as int,
+      ),
+      willAutoRenew: map['willAutoRenew'] as bool?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'StoreEntitlement(productId: $productId, expiryDate: $expiryDate, '
+      'willAutoRenew: $willAutoRenew)';
+}

--- a/lib/services/in_app_purchase_service.dart
+++ b/lib/services/in_app_purchase_service.dart
@@ -6,6 +6,7 @@ import '../core/errors/app_exceptions.dart';
 import '../core/errors/error_handler.dart';
 import '../models/plans/plan.dart';
 import 'interfaces/in_app_purchase_service_interface.dart';
+import 'interfaces/store_entitlement_service_interface.dart';
 import 'interfaces/subscription_state_service_interface.dart';
 import 'interfaces/logging_service_interface.dart';
 import 'interfaces/subscription_sync_result.dart';
@@ -23,6 +24,7 @@ class InAppPurchaseService
     with ServiceLogging, PurchaseEventHandler
     implements IInAppPurchaseService {
   final ISubscriptionStateService _stateService;
+  final IStoreEntitlementService _entitlementService;
   final ILoggingService? _loggingService;
 
   @override
@@ -83,8 +85,10 @@ class InAppPurchaseService
 
   InAppPurchaseService({
     required ISubscriptionStateService stateService,
+    required IStoreEntitlementService entitlementService,
     ILoggingService? logger,
   }) : _stateService = stateService,
+       _entitlementService = entitlementService,
        _loggingService = logger {
     _productDelegate = PurchaseProductDelegate(
       getStateService: () => _stateService,
@@ -102,9 +106,8 @@ class InAppPurchaseService
     _syncDelegate = SubscriptionSyncDelegate(
       getStateService: () => _stateService,
       getInAppPurchase: () => _inAppPurchase,
-      purchaseStream: _purchaseStreamController.stream,
+      getEntitlementService: () => _entitlementService,
       loggingService: _loggingService,
-      onSyncStateChanged: (syncing) => isSyncing = syncing,
     );
   }
 

--- a/lib/services/interfaces/store_entitlement_service_interface.dart
+++ b/lib/services/interfaces/store_entitlement_service_interface.dart
@@ -1,0 +1,13 @@
+import '../../core/result/result.dart';
+import '../../models/store_entitlement.dart';
+
+/// StoreKit2 のエンタイトルメント（Apple 管理の実有効期限）を取得するサービス。
+///
+/// 戻り値の3状態を区別する点が重要:
+/// - `Success(StoreEntitlement)`: 現在有効な購読がある
+/// - `Success(null)`: 有効な購読が無い（失効・解約・返金・未購入）→ Basic 降格の根拠
+/// - `Failure`: 取得自体に失敗（非iOS・チャネル未登録・通信不可等）→ 状態は変更しない
+abstract class IStoreEntitlementService {
+  /// 現在有効な自動更新サブスクリプションのエンタイトルメントを返す。
+  Future<Result<StoreEntitlement?>> getActiveSubscription();
+}

--- a/lib/services/store_entitlement_service.dart
+++ b/lib/services/store_entitlement_service.dart
@@ -77,6 +77,19 @@ class StoreEntitlementService implements IStoreEntitlementService {
           originalError: e,
         ),
       );
+    } catch (e) {
+      // ペイロードのパース失敗など想定外のエラーも Result 契約を守って Failure に収束させる。
+      _logger.warning(
+        'StoreKit2: invalid entitlement payload',
+        context: _logContext,
+        data: e.toString(),
+      );
+      return Failure(
+        ServiceException(
+          'Invalid StoreKit2 entitlement payload',
+          originalError: e,
+        ),
+      );
     }
   }
 }

--- a/lib/services/store_entitlement_service.dart
+++ b/lib/services/store_entitlement_service.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/services.dart';
+
+import '../constants/subscription_constants.dart';
+import '../core/errors/app_exceptions.dart';
+import '../core/result/result.dart';
+import '../models/store_entitlement.dart';
+import 'interfaces/logging_service_interface.dart';
+import 'interfaces/store_entitlement_service_interface.dart';
+
+/// StoreKit2 のエンタイトルメントを MethodChannel 経由で取得する実装。
+///
+/// ネイティブ側ハンドラ: `ios/Runner/StoreKit2EntitlementHandler.swift`
+class StoreEntitlementService implements IStoreEntitlementService {
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'smart_photo_diary/storekit2',
+  );
+
+  static const String _logContext = 'StoreEntitlementService';
+
+  final ILoggingService _logger;
+  final MethodChannel _channel;
+
+  StoreEntitlementService({
+    required ILoggingService logger,
+    MethodChannel? channel,
+  }) : _logger = logger,
+       _channel = channel ?? _defaultChannel;
+
+  @override
+  Future<Result<StoreEntitlement?>> getActiveSubscription() async {
+    try {
+      final result = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        'getActiveSubscription',
+        {
+          'productIds': [
+            SubscriptionConstants.premiumMonthlyProductId,
+            SubscriptionConstants.premiumYearlyProductId,
+          ],
+        },
+      );
+
+      if (result == null) {
+        _logger.info(
+          'StoreKit2: no active subscription entitlement',
+          context: _logContext,
+        );
+        return const Success(null);
+      }
+
+      final entitlement = StoreEntitlement.fromMap(result);
+      _logger.info(
+        'StoreKit2: active entitlement found',
+        context: _logContext,
+        data: entitlement.toString(),
+      );
+      return Success(entitlement);
+    } on MissingPluginException catch (e) {
+      // 非iOS、またはチャネル未登録。状態変更の根拠にはしない（Failure）。
+      _logger.warning(
+        'StoreKit2: channel unavailable (non-iOS or not registered)',
+        context: _logContext,
+        data: e.toString(),
+      );
+      return Failure(
+        ServiceException('StoreKit2 channel unavailable', originalError: e),
+      );
+    } on PlatformException catch (e) {
+      _logger.warning(
+        'StoreKit2: platform error while fetching entitlement',
+        context: _logContext,
+        data: e.toString(),
+      );
+      return Failure(
+        ServiceException(
+          'Failed to fetch StoreKit2 entitlement',
+          details: e.message,
+          originalError: e,
+        ),
+      );
+    }
+  }
+}

--- a/lib/services/subscription_sync_delegate.dart
+++ b/lib/services/subscription_sync_delegate.dart
@@ -5,40 +5,36 @@ import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
 import '../constants/subscription_constants.dart';
 import '../core/result/result.dart';
 import '../models/plans/plan_factory.dart';
+import '../models/store_entitlement.dart';
 import '../models/subscription_status.dart';
-import 'interfaces/in_app_purchase_service_interface.dart';
 import 'interfaces/logging_service_interface.dart';
+import 'interfaces/store_entitlement_service_interface.dart';
 import 'interfaces/subscription_state_service_interface.dart';
 import 'interfaces/subscription_sync_result.dart';
 import 'purchase_error_handler_mixin.dart';
 
-/// 起動時のApp Store購読状態同期を担当するデリゲート
+/// 起動時のApp Store購読状態同期を担当するデリゲート。
 ///
-/// ローカルがPremiumなのにStoreに有効購読が無い場合にBasicへ降格させる。
-/// ネットワークエラー時は誤Basic化を防ぐため現状維持する。
+/// StoreKit2 の Transaction.currentEntitlements から取得した「Apple 管理の実有効期限」を
+/// 真実として、ローカルのサブスクリプション状態を補正する。
+/// - 有効な購読が無い → Basic へ降格
+/// - 有効な購読がある → 実有効期限・プランをローカルへ反映
+/// - 取得に失敗 → 誤降格を防ぐため現状維持
 class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
   final ISubscriptionStateService Function() _getStateService;
   final InAppPurchase? Function() _getInAppPurchase;
-  final Stream<PurchaseResult> _purchaseStream;
+  final IStoreEntitlementService Function() _getEntitlementService;
   final ILoggingService? _loggingService;
-  final Duration _timeout;
-
-  /// sync中フラグの制御コールバック — PurchaseEventHandler 側の isSyncing を操作する
-  final void Function(bool)? _onSyncStateChanged;
 
   SubscriptionSyncDelegate({
     required ISubscriptionStateService Function() getStateService,
     required InAppPurchase? Function() getInAppPurchase,
-    required Stream<PurchaseResult> purchaseStream,
+    required IStoreEntitlementService Function() getEntitlementService,
     ILoggingService? loggingService,
-    Duration timeout = SubscriptionConstants.storeSyncTimeout,
-    void Function(bool)? onSyncStateChanged,
   }) : _getStateService = getStateService,
        _getInAppPurchase = getInAppPurchase,
-       _purchaseStream = purchaseStream,
-       _loggingService = loggingService,
-       _timeout = timeout,
-       _onSyncStateChanged = onSyncStateChanged;
+       _getEntitlementService = getEntitlementService,
+       _loggingService = loggingService;
 
   @override
   String get logTag => 'SubscriptionSyncDelegate';
@@ -72,8 +68,8 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       return Success(SubscriptionSyncResult.skipped());
     }
 
-    final currentPlanId = statusResult.value.planId;
-    if (currentPlanId == SubscriptionConstants.basicPlanId) {
+    final current = statusResult.value;
+    if (current.planId == SubscriptionConstants.basicPlanId) {
       _loggingService?.debug(
         'Store sync: already basic plan, no sync needed',
         context: logTag,
@@ -81,53 +77,41 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       return Success(SubscriptionSyncResult.noChange());
     }
 
-    var restoredCount = 0;
-    final restoredProductIds = <String>{};
-    var hasError = false;
-
-    final subscription = _purchaseStream.listen((result) {
-      if (result.status == PurchaseStatus.restored) {
-        restoredCount++;
-        final productId = result.productId;
-        if (productId != null) restoredProductIds.add(productId);
-      } else if (result.status == PurchaseStatus.error ||
-          result.status == PurchaseStatus.networkError ||
-          result.status == PurchaseStatus.storeNotAvailable) {
-        hasError = true;
-      }
-    });
-
-    _onSyncStateChanged?.call(true);
-    try {
-      await getInAppPurchase()!.restorePurchases();
-      await Future<void>.delayed(_timeout);
-    } catch (e) {
-      _loggingService?.error(
-        'Store sync: restorePurchases failed',
-        context: logTag,
-        error: e,
-      );
-      return Success(SubscriptionSyncResult.error());
-    } finally {
-      await subscription.cancel();
-      _onSyncStateChanged?.call(false);
-    }
-
-    if (hasError) {
+    final entitlementResult = await _getEntitlementService()
+        .getActiveSubscription();
+    if (entitlementResult.isFailure) {
+      // 取得失敗（非iOS・チャネル未登録・通信不可等）は誤降格を防ぐため現状維持。
       _loggingService?.warning(
-        'Store sync: error received, keeping current status',
+        'Store sync: failed to fetch entitlement, keeping current status',
         context: logTag,
+        data: entitlementResult.error.message,
       );
       return Success(SubscriptionSyncResult.error());
     }
 
-    if (restoredCount == 0) {
+    return _applySync(current, entitlementResult.value);
+  }
+
+  /// StoreKit2 のエンタイトルメント結果をローカル状態へ反映する。
+  ///
+  /// 引数:
+  /// - [current]: forcePlan などの上書きを含まない、DB上の生のサブスクリプション状態
+  /// - [entitlement]: StoreKit2 が返した現在有効な購読。`null` なら有効な購読は存在しない
+  ///   （失効・解約・返金・未購入）
+  ///
+  /// 「期限切れの restored イベントを active と誤認して期限を延長する」旧バグを防ぐため、
+  /// entitlement の有無のみを根拠に降格/更新を決める。
+  Future<Result<SubscriptionSyncResult>> _applySync(
+    SubscriptionStatus current,
+    StoreEntitlement? entitlement,
+  ) async {
+    if (entitlement == null) {
       _loggingService?.info(
-        'Store sync: no valid subscriptions found, downgrading to Basic',
+        'Store sync: no active entitlement, downgrading to Basic',
         context: logTag,
       );
-      final current = statusResult.value;
-      final downgradedStatus = SubscriptionStatus(
+      // expiryDate を null に戻すため copyWith ではなく新規生成する。
+      final downgraded = SubscriptionStatus(
         planId: SubscriptionConstants.basicPlanId,
         isActive: true,
         startDate: DateTime.now(),
@@ -136,7 +120,7 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
         lastResetDate: current.lastResetDate,
         autoRenewal: false,
       );
-      final saveResult = await getStateService().updateStatus(downgradedStatus);
+      final saveResult = await getStateService().updateStatus(downgraded);
       if (saveResult.isFailure) {
         _loggingService?.error(
           'Store sync: failed to save downgraded status',
@@ -147,70 +131,41 @@ class SubscriptionSyncDelegate with PurchaseErrorHandlerMixin {
       return Success(SubscriptionSyncResult.downgradedToBasic());
     }
 
-    _loggingService?.info(
-      'Store sync: subscriptions found',
-      context: logTag,
-      data: {'restoredCount': restoredCount},
-    );
-
-    // 複数の distinct productId が restored された場合、どちらが現在アクティブかを
-    // イベント配信順に依存せず決定できないため、自動 refresh はスキップする。
-    if (restoredProductIds.length > 1) {
+    final plan = PlanFactory.getPlanByProductId(entitlement.productId);
+    if (plan == null) {
+      // 自社の Premium 商品ID以外が返るケースは想定外。誤った降格・更新を避け現状維持。
       _loggingService?.warning(
-        'Store sync: multiple distinct product IDs restored, skipping auto-refresh',
+        'Store sync: unknown product ID in entitlement, keeping current status',
         context: logTag,
-        data: {'productIds': restoredProductIds.join(',')},
+        data: {'productId': entitlement.productId},
       );
-      return Success(SubscriptionSyncResult.synced(restoredCount));
+      return Success(SubscriptionSyncResult.error());
     }
 
-    // ローカルの expiryDate が切れている（または未設定）か、Store 側でプランが
-    // 変更されている場合に更新する。
-    // in_app_purchase は自動更新に対して purchased イベントを発火しないため、
-    // 起動時同期がローカル期限を最新に保つ唯一の手段になる。
-    // プラン変更（月額→年額など）は期限が有効中でも即座に反映する。
-    final current = statusResult.value;
-    final now = DateTime.now();
-    final restoredProductId = restoredProductIds.isEmpty
-        ? null
-        : restoredProductIds.first;
-    final activePlan = PlanFactory.getPlanByProductId(restoredProductId ?? '');
-    final activePlanId = activePlan?.id ?? current.planId;
-    final isExpiryStale =
-        current.expiryDate == null || current.expiryDate!.isBefore(now);
-    final isPlanChanged = activePlanId != current.planId;
-
-    if (isExpiryStale || isPlanChanged) {
-      final duration = Duration(
-        days: (activePlan?.isYearly ?? false)
-            ? SubscriptionConstants.subscriptionYearDays
-            : SubscriptionConstants.subscriptionMonthDays,
+    // willAutoRenew が null（取得不能）のときは既存値を保持し、
+    // 解約済み（autoRenewal=false）を誤って true で上書きしない。
+    final refreshed = current.copyWith(
+      planId: plan.id,
+      expiryDate: entitlement.expiryDate,
+      autoRenewal: entitlement.willAutoRenew ?? current.autoRenewal,
+    );
+    final saveResult = await getStateService().updateStatus(refreshed);
+    if (saveResult.isFailure) {
+      _loggingService?.warning(
+        'Store sync: failed to refresh subscription state',
+        context: logTag,
       );
-      final refreshed = current.copyWith(
-        planId: activePlanId,
-        expiryDate: now.add(duration),
-        autoRenewal: true,
-      );
-      final saveResult = await getStateService().updateStatus(refreshed);
-      if (saveResult.isFailure) {
-        _loggingService?.warning(
-          'Store sync: failed to refresh subscription state',
-          context: logTag,
-        );
-        return Success(SubscriptionSyncResult.error());
-      } else {
-        _loggingService?.info(
-          'Store sync: refreshed subscription state',
-          context: logTag,
-          data: {
-            'planId': activePlanId,
-            'planChanged': isPlanChanged,
-            'expiryRefreshed': isExpiryStale,
-          },
-        );
-      }
+      return Success(SubscriptionSyncResult.error());
     }
 
-    return Success(SubscriptionSyncResult.synced(restoredCount));
+    _loggingService?.info(
+      'Store sync: refreshed subscription state from entitlement',
+      context: logTag,
+      data: {
+        'planId': plan.id,
+        'expiryDate': entitlement.expiryDate.toString(),
+      },
+    );
+    return Success(SubscriptionSyncResult.synced(1));
   }
 }

--- a/test/unit/helpers/subscription_test_helpers.dart
+++ b/test/unit/helpers/subscription_test_helpers.dart
@@ -1,12 +1,18 @@
 import 'package:mocktail/mocktail.dart';
+import 'package:smart_photo_diary/core/result/result.dart';
+import 'package:smart_photo_diary/models/store_entitlement.dart';
 import 'package:smart_photo_diary/services/subscription_service.dart';
 import 'package:smart_photo_diary/services/subscription_state_service.dart';
 import 'package:smart_photo_diary/services/ai_usage_service.dart';
 import 'package:smart_photo_diary/services/feature_access_service.dart';
 import 'package:smart_photo_diary/services/in_app_purchase_service.dart';
 import 'package:smart_photo_diary/services/interfaces/logging_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/store_entitlement_service_interface.dart';
 
 class _MockLoggingService extends Mock implements ILoggingService {}
+
+class _MockStoreEntitlementService extends Mock
+    implements IStoreEntitlementService {}
 
 /// テスト用のサブスクリプションサービス構築結果
 ///
@@ -52,8 +58,13 @@ class SubscriptionTestHelpers {
       stateService: stateService,
       logger: mockLogger,
     );
+    final mockEntitlementService = _MockStoreEntitlementService();
+    when(
+      () => mockEntitlementService.getActiveSubscription(),
+    ).thenAnswer((_) async => const Success<StoreEntitlement?>(null));
     final purchaseService = InAppPurchaseService(
       stateService: stateService,
+      entitlementService: mockEntitlementService,
       logger: mockLogger,
     );
 

--- a/test/unit/services/in_app_purchase_service_test.dart
+++ b/test/unit/services/in_app_purchase_service_test.dart
@@ -5,7 +5,9 @@ import 'package:smart_photo_diary/core/result/result.dart';
 import 'package:smart_photo_diary/models/plans/basic_plan.dart';
 import 'package:smart_photo_diary/models/plans/premium_monthly_plan.dart';
 import 'package:smart_photo_diary/models/subscription_status.dart';
+import 'package:smart_photo_diary/models/store_entitlement.dart';
 import 'package:smart_photo_diary/services/in_app_purchase_service.dart';
+import 'package:smart_photo_diary/services/interfaces/store_entitlement_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
 
 import '../../integration/mocks/mock_services.dart';
@@ -13,9 +15,13 @@ import '../../integration/mocks/mock_services.dart';
 class MockSubscriptionStateService extends Mock
     implements ISubscriptionStateService {}
 
+class MockStoreEntitlementService extends Mock
+    implements IStoreEntitlementService {}
+
 void main() {
   late InAppPurchaseService service;
   late MockSubscriptionStateService mockStateService;
+  late MockStoreEntitlementService mockEntitlementService;
   late MockILoggingService mockLogger;
 
   setUpAll(() {
@@ -33,9 +39,14 @@ void main() {
 
   setUp(() {
     mockStateService = MockSubscriptionStateService();
+    mockEntitlementService = MockStoreEntitlementService();
     mockLogger = TestServiceSetup.getLoggingService();
+    when(
+      () => mockEntitlementService.getActiveSubscription(),
+    ).thenAnswer((_) async => const Success<StoreEntitlement?>(null));
     service = InAppPurchaseService(
       stateService: mockStateService,
+      entitlementService: mockEntitlementService,
       logger: mockLogger,
     );
   });

--- a/test/unit/services/store_entitlement_service_test.dart
+++ b/test/unit/services/store_entitlement_service_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_photo_diary/constants/subscription_constants.dart';
+import 'package:smart_photo_diary/services/store_entitlement_service.dart';
+
+import '../../integration/mocks/mock_services.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('smart_photo_diary/storekit2');
+  late StoreEntitlementService service;
+  late List<MethodCall> calls;
+
+  setUpAll(() {
+    registerMockFallbacks();
+  });
+
+  setUp(() {
+    calls = [];
+    service = StoreEntitlementService(
+      logger: TestServiceSetup.getLoggingService(),
+      channel: channel,
+    );
+  });
+
+  void setHandler(Future<Object?>? Function(MethodCall) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return handler(call);
+        });
+  }
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    TestServiceSetup.clearAllMocks();
+  });
+
+  test('有効なエンタイトルメントを返す → Success(StoreEntitlement)', () async {
+    final expiryMs = DateTime(2030, 1, 1).millisecondsSinceEpoch;
+    setHandler(
+      (_) async => {
+        'productId': SubscriptionConstants.premiumMonthlyProductId,
+        'expiryDateMs': expiryMs,
+        'isActive': true,
+      },
+    );
+
+    final result = await service.getActiveSubscription();
+
+    expect(result.isSuccess, isTrue);
+    expect(
+      result.value!.productId,
+      SubscriptionConstants.premiumMonthlyProductId,
+    );
+    expect(result.value!.expiryDate.millisecondsSinceEpoch, expiryMs);
+    // 商品IDがネイティブへ渡されていること
+    final args = calls.single.arguments as Map<dynamic, dynamic>;
+    expect(
+      args['productIds'],
+      contains(SubscriptionConstants.premiumMonthlyProductId),
+    );
+  });
+
+  test('有効な購読が無い(nullを返す) → Success(null)', () async {
+    setHandler((_) async => null);
+
+    final result = await service.getActiveSubscription();
+
+    expect(result.isSuccess, isTrue);
+    expect(result.value, isNull);
+  });
+
+  test('PlatformException → Failure', () async {
+    setHandler((_) async => throw PlatformException(code: 'STOREKIT_ERROR'));
+
+    final result = await service.getActiveSubscription();
+
+    expect(result.isFailure, isTrue);
+  });
+
+  test('チャネル未登録(MissingPluginException相当) → Failure', () async {
+    // ハンドラ未設定 = MissingPluginException が送出される
+    final result = await service.getActiveSubscription();
+
+    expect(result.isFailure, isTrue);
+  });
+}

--- a/test/unit/services/store_entitlement_service_test.dart
+++ b/test/unit/services/store_entitlement_service_test.dart
@@ -87,4 +87,17 @@ void main() {
 
     expect(result.isFailure, isTrue);
   });
+
+  test('不正なペイロード（型不一致）→ throwせず Failure', () async {
+    setHandler(
+      (_) async => {
+        'productId': 123, // String を期待するが int
+        'expiryDateMs': 'not-a-number',
+      },
+    );
+
+    final result = await service.getActiveSubscription();
+
+    expect(result.isFailure, isTrue);
+  });
 }

--- a/test/unit/services/subscription_sync_delegate_test.dart
+++ b/test/unit/services/subscription_sync_delegate_test.dart
@@ -1,13 +1,12 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:in_app_purchase/in_app_purchase.dart' hide PurchaseStatus;
 import 'package:mocktail/mocktail.dart';
 import 'package:smart_photo_diary/constants/subscription_constants.dart';
 import 'package:smart_photo_diary/core/errors/app_exceptions.dart';
 import 'package:smart_photo_diary/core/result/result.dart';
+import 'package:smart_photo_diary/models/store_entitlement.dart';
 import 'package:smart_photo_diary/models/subscription_status.dart';
-import 'package:smart_photo_diary/services/interfaces/in_app_purchase_service_interface.dart';
+import 'package:smart_photo_diary/services/interfaces/store_entitlement_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_state_service_interface.dart';
 import 'package:smart_photo_diary/services/interfaces/subscription_sync_result.dart';
 import 'package:smart_photo_diary/services/subscription_sync_delegate.dart';
@@ -19,14 +18,14 @@ class _MockSubscriptionStateService extends Mock
 
 class _MockInAppPurchase extends Mock implements InAppPurchase {}
 
+class _MockStoreEntitlementService extends Mock
+    implements IStoreEntitlementService {}
+
 void main() {
   late _MockSubscriptionStateService mockStateService;
   late _MockInAppPurchase mockIAP;
+  late _MockStoreEntitlementService mockEntitlementService;
   late MockILoggingService mockLogger;
-  late StreamController<PurchaseResult> purchaseStreamController;
-
-  // テスト用に短いタイムアウトを使用（実際の3秒を待たない）
-  const testTimeout = Duration(milliseconds: 50);
 
   SubscriptionStatus buildStatus({
     String planId = SubscriptionConstants.basicPlanId,
@@ -43,17 +42,12 @@ void main() {
     );
   }
 
-  SubscriptionSyncDelegate buildDelegate({
-    bool iapAvailable = true,
-    void Function(bool)? onSyncStateChanged,
-  }) {
+  SubscriptionSyncDelegate buildDelegate({bool iapAvailable = true}) {
     return SubscriptionSyncDelegate(
       getStateService: () => mockStateService,
       getInAppPurchase: () => iapAvailable ? mockIAP : null,
-      purchaseStream: purchaseStreamController.stream,
+      getEntitlementService: () => mockEntitlementService,
       loggingService: mockLogger,
-      timeout: testTimeout,
-      onSyncStateChanged: onSyncStateChanged,
     );
   }
 
@@ -73,20 +67,16 @@ void main() {
   setUp(() {
     mockStateService = _MockSubscriptionStateService();
     mockIAP = _MockInAppPurchase();
+    mockEntitlementService = _MockStoreEntitlementService();
     mockLogger = TestServiceSetup.getLoggingService();
-    purchaseStreamController = StreamController<PurchaseResult>.broadcast(
-      sync: true,
-    );
 
     when(() => mockStateService.isInitialized).thenReturn(true);
-    when(() => mockIAP.restorePurchases()).thenAnswer((_) async {});
     when(
       () => mockStateService.updateStatus(any()),
     ).thenAnswer((_) async => const Success(null));
   });
 
-  tearDown(() async {
-    await purchaseStreamController.close();
+  tearDown(() {
     TestServiceSetup.clearAllMocks();
   });
 
@@ -99,6 +89,7 @@ void main() {
       expect(result.isSuccess, isTrue);
       expect(result.value.outcome, SubscriptionSyncOutcome.skipped);
       verifyNever(() => mockStateService.updateStatus(any()));
+      verifyNever(() => mockEntitlementService.getActiveSubscription());
     });
 
     test('stateService未初期化 → skipped を返し状態変更しない', () async {
@@ -112,7 +103,7 @@ void main() {
       verifyNever(() => mockStateService.updateStatus(any()));
     });
 
-    test('ローカルがBasic → noChange を返し状態変更しない', () async {
+    test('ローカルがBasic → noChange、エンタイトルメント取得もしない', () async {
       when(
         () => mockStateService.getRawStatus(),
       ).thenAnswer((_) async => Success(buildStatus()));
@@ -122,379 +113,7 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.value.outcome, SubscriptionSyncOutcome.noChange);
-      verifyNever(() => mockIAP.restorePurchases());
-      verifyNever(() => mockStateService.updateStatus(any()));
-    });
-
-    test('ローカルがPremium、restoredゼロ、エラーなし → Basic に降格', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ),
-        ),
-      );
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
-      verify(() => mockStateService.updateStatus(any())).called(1);
-    });
-
-    test(
-      'ローカルがPremium、restored 1件、expiryDate未来 → synced(1)、updateStatus呼ばれない',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumMonthlyPlanId,
-              expiryDate: DateTime.now().add(const Duration(days: 15)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        expect(result.value.restoredCount, 1);
-        verifyNever(() => mockStateService.updateStatus(any()));
-      },
-    );
-
-    test(
-      'ローカルが月額Premium、restored が年額productId、expiryDate未来 → planId更新・365日期限でリフレッシュ',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumMonthlyPlanId,
-              expiryDate: DateTime.now().add(const Duration(days: 15)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumYearlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-        final before = DateTime.now();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        final captured = verify(
-          () => mockStateService.updateStatus(captureAny()),
-        ).captured;
-        final saved = captured.first as SubscriptionStatus;
-        expect(saved.planId, SubscriptionConstants.premiumYearlyPlanId);
-        final expectedExpiry = before.add(
-          const Duration(days: SubscriptionConstants.subscriptionYearDays),
-        );
-        expect(
-          saved.expiryDate!.isAfter(
-            expectedExpiry.subtract(const Duration(seconds: 1)),
-          ),
-          isTrue,
-        );
-      },
-    );
-
-    test(
-      'ローカルが年額Premium、restored が月額productId、expiryDate未来 → planId更新・30日期限でリフレッシュ',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumYearlyPlanId,
-              expiryDate: DateTime.now().add(const Duration(days: 300)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-        final before = DateTime.now();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        final captured = verify(
-          () => mockStateService.updateStatus(captureAny()),
-        ).captured;
-        final saved = captured.first as SubscriptionStatus;
-        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
-        final expectedExpiry = before.add(
-          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
-        );
-        expect(
-          saved.expiryDate!.isAfter(
-            expectedExpiry.subtract(const Duration(seconds: 1)),
-          ),
-          isTrue,
-        );
-      },
-    );
-
-    test(
-      'ローカルがPremium、restored 1件、expiryDate過去 → expiryDate更新してsynced',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumMonthlyPlanId,
-              expiryDate: DateTime.now().subtract(const Duration(days: 1)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        final captured = verify(
-          () => mockStateService.updateStatus(captureAny()),
-        ).captured;
-        final saved = captured.first as SubscriptionStatus;
-        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
-        expect(saved.expiryDate, isNotNull);
-        expect(saved.expiryDate!.isAfter(DateTime.now()), isTrue);
-      },
-    );
-
-    test(
-      'ローカルがPremium月額、restored 1件、expiryDate null → 30日の期限でリフレッシュ',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(planId: SubscriptionConstants.premiumMonthlyPlanId),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-        final before = DateTime.now();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        final captured = verify(
-          () => mockStateService.updateStatus(captureAny()),
-        ).captured;
-        final saved = captured.first as SubscriptionStatus;
-        final expectedExpiry = before.add(
-          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
-        );
-        expect(
-          saved.expiryDate!.isAfter(
-            expectedExpiry.subtract(const Duration(seconds: 1)),
-          ),
-          isTrue,
-        );
-      },
-    );
-
-    test('ローカルがPremium年額、restored 1件、expiryDate過去 → 365日の期限でリフレッシュ', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumYearlyPlanId,
-            expiryDate: DateTime.now().subtract(const Duration(days: 1)),
-          ),
-        ),
-      );
-      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-        purchaseStreamController.add(
-          const PurchaseResult(
-            status: PurchaseStatus.restored,
-            productId: SubscriptionConstants.premiumYearlyProductId,
-          ),
-        );
-      });
-      final delegate = buildDelegate();
-      final before = DateTime.now();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      final captured = verify(
-        () => mockStateService.updateStatus(captureAny()),
-      ).captured;
-      final saved = captured.first as SubscriptionStatus;
-      final expectedExpiry = before.add(
-        const Duration(days: SubscriptionConstants.subscriptionYearDays),
-      );
-      expect(
-        saved.expiryDate!.isAfter(
-          expectedExpiry.subtract(const Duration(seconds: 1)),
-        ),
-        isTrue,
-      );
-    });
-
-    test('restored 1件、expiryDate過去、updateStatus失敗 → error を返す', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().subtract(const Duration(days: 1)),
-          ),
-        ),
-      );
-      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-        purchaseStreamController.add(
-          const PurchaseResult(
-            status: PurchaseStatus.restored,
-            productId: SubscriptionConstants.premiumMonthlyProductId,
-          ),
-        );
-      });
-      when(
-        () => mockStateService.updateStatus(any()),
-      ).thenAnswer((_) async => const Failure(ServiceException('write error')));
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.error);
-    });
-
-    test(
-      'ローカルが年額Premium、restored が月額productId、expiryDate過去 → 月額30日・planIdも月額に更新',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumYearlyPlanId,
-              expiryDate: DateTime.now().subtract(const Duration(days: 1)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-        final before = DateTime.now();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        final captured = verify(
-          () => mockStateService.updateStatus(captureAny()),
-        ).captured;
-        final saved = captured.first as SubscriptionStatus;
-        expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
-        final expectedExpiry = before.add(
-          const Duration(days: SubscriptionConstants.subscriptionMonthDays),
-        );
-        expect(
-          saved.expiryDate!.isAfter(
-            expectedExpiry.subtract(const Duration(seconds: 1)),
-          ),
-          isTrue,
-        );
-        expect(
-          saved.expiryDate!.isBefore(
-            before.add(
-              const Duration(days: SubscriptionConstants.subscriptionYearDays),
-            ),
-          ),
-          isTrue,
-        );
-      },
-    );
-
-    test('ローカルがPremium、error イベントあり → error を返し降格しない', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ),
-        ),
-      );
-      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-        purchaseStreamController.add(
-          const PurchaseResult(
-            status: PurchaseStatus.error,
-            errorMessage: 'network error',
-          ),
-        );
-      });
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.error);
-      verifyNever(() => mockStateService.updateStatus(any()));
-    });
-
-    test('restorePurchases() が例外スロー → error を返し降格しない', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ),
-        ),
-      );
-      when(
-        () => mockIAP.restorePurchases(),
-      ).thenThrow(const ServiceException('Store unavailable'));
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockEntitlementService.getActiveSubscription());
       verifyNever(() => mockStateService.updateStatus(any()));
     });
 
@@ -508,10 +127,10 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.value.outcome, SubscriptionSyncOutcome.skipped);
-      verifyNever(() => mockIAP.restorePurchases());
+      verifyNever(() => mockEntitlementService.getActiveSubscription());
     });
 
-    test('ローカルがPremium、storeNotAvailable イベント → error を返し降格しない', () async {
+    test('ローカルがPremium、有効なエンタイトルメント無し(null) → Basic に降格', () async {
       when(() => mockStateService.getRawStatus()).thenAnswer(
         (_) async => Success(
           buildStatus(
@@ -520,29 +139,9 @@ void main() {
           ),
         ),
       );
-      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-        purchaseStreamController.add(
-          const PurchaseResult(status: PurchaseStatus.storeNotAvailable),
-        );
-      });
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.error);
-      verifyNever(() => mockStateService.updateStatus(any()));
-    });
-
-    test('ローカルがPremium、降格時に既存monthlyUsageCountが保持される', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ).copyWith(monthlyUsageCount: 7),
-        ),
-      );
+      when(
+        () => mockEntitlementService.getActiveSubscription(),
+      ).thenAnswer((_) async => const Success(null));
       final delegate = buildDelegate();
 
       final result = await delegate.syncSubscriptionWithStore();
@@ -556,15 +155,243 @@ void main() {
       expect(saved.planId, SubscriptionConstants.basicPlanId);
       expect(saved.isActive, isTrue);
       expect(saved.expiryDate, isNull);
-      expect(saved.monthlyUsageCount, 7);
+      expect(saved.autoRenewal, isFalse);
     });
 
-    test('ローカルがPremium、降格時updateStatus失敗 → error を返し降格しない', () async {
+    test('降格時に既存の monthlyUsageCount が保持される', () async {
       when(() => mockStateService.getRawStatus()).thenAnswer(
         (_) async => Success(
           buildStatus(
             planId: SubscriptionConstants.premiumMonthlyPlanId,
             expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ).copyWith(monthlyUsageCount: 7),
+        ),
+      );
+      when(
+        () => mockEntitlementService.getActiveSubscription(),
+      ).thenAnswer((_) async => const Success(null));
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      expect(saved.monthlyUsageCount, 7);
+    });
+
+    test('ローカルがPremium、有効なエンタイトルメントあり → 実有効期限でリフレッシュしsynced', () async {
+      final realExpiry = DateTime.now().add(const Duration(days: 23));
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => Success(
+          StoreEntitlement(
+            productId: SubscriptionConstants.premiumMonthlyProductId,
+            expiryDate: realExpiry,
+            willAutoRenew: true,
+          ),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      expect(saved.planId, SubscriptionConstants.premiumMonthlyPlanId);
+      expect(saved.expiryDate, realExpiry);
+      expect(saved.autoRenewal, isTrue);
+    });
+
+    test('解約済み(willAutoRenew=false)の購読 → autoRenewal=false で保存', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => Success(
+          StoreEntitlement(
+            productId: SubscriptionConstants.premiumMonthlyProductId,
+            expiryDate: DateTime.now().add(const Duration(days: 23)),
+            willAutoRenew: false,
+          ),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      expect(saved.autoRenewal, isFalse);
+    });
+
+    test('willAutoRenew が null（取得不能）→ 既存の autoRenewal を保持し上書きしない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ).copyWith(autoRenewal: false),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => Success(
+          StoreEntitlement(
+            productId: SubscriptionConstants.premiumMonthlyProductId,
+            expiryDate: DateTime.now().add(const Duration(days: 23)),
+            willAutoRenew: null,
+          ),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+      final captured = verify(
+        () => mockStateService.updateStatus(captureAny()),
+      ).captured;
+      final saved = captured.first as SubscriptionStatus;
+      expect(saved.autoRenewal, isFalse);
+    });
+
+    test(
+      'ローカルが月額、エンタイトルメントが年額productId → planId・期限を年額エンタイトルメントに合わせる',
+      () async {
+        final realExpiry = DateTime.now().add(const Duration(days: 360));
+        when(() => mockStateService.getRawStatus()).thenAnswer(
+          (_) async => Success(
+            buildStatus(
+              planId: SubscriptionConstants.premiumMonthlyPlanId,
+              expiryDate: DateTime.now().add(const Duration(days: 15)),
+            ),
+          ),
+        );
+        when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+          (_) async => Success(
+            StoreEntitlement(
+              productId: SubscriptionConstants.premiumYearlyProductId,
+              expiryDate: realExpiry,
+            ),
+          ),
+        );
+        final delegate = buildDelegate();
+
+        final result = await delegate.syncSubscriptionWithStore();
+
+        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
+        final captured = verify(
+          () => mockStateService.updateStatus(captureAny()),
+        ).captured;
+        final saved = captured.first as SubscriptionStatus;
+        expect(saved.planId, SubscriptionConstants.premiumYearlyPlanId);
+        expect(saved.expiryDate, realExpiry);
+      },
+    );
+
+    test('エンタイトルメント取得が Failure → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => const Failure(ServiceException('channel unavailable')),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('エンタイトルメントが未知のproductId → error を返し降格しない', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => Success(
+          StoreEntitlement(
+            productId: 'unknown_product_id',
+            expiryDate: DateTime.now().add(const Duration(days: 30)),
+          ),
+        ),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+      verifyNever(() => mockStateService.updateStatus(any()));
+    });
+
+    test('降格時 updateStatus 失敗 → error を返す', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(
+        () => mockEntitlementService.getActiveSubscription(),
+      ).thenAnswer((_) async => const Success(null));
+      when(() => mockStateService.updateStatus(any())).thenAnswer(
+        (_) async => const Failure(ServiceException('Hive write error')),
+      );
+      final delegate = buildDelegate();
+
+      final result = await delegate.syncSubscriptionWithStore();
+
+      expect(result.value.outcome, SubscriptionSyncOutcome.error);
+    });
+
+    test('リフレッシュ時 updateStatus 失敗 → error を返す', () async {
+      when(() => mockStateService.getRawStatus()).thenAnswer(
+        (_) async => Success(
+          buildStatus(
+            planId: SubscriptionConstants.premiumMonthlyPlanId,
+            expiryDate: DateTime.now().add(const Duration(days: 15)),
+          ),
+        ),
+      );
+      when(() => mockEntitlementService.getActiveSubscription()).thenAnswer(
+        (_) async => Success(
+          StoreEntitlement(
+            productId: SubscriptionConstants.premiumMonthlyProductId,
+            expiryDate: DateTime.now().add(const Duration(days: 23)),
           ),
         ),
       );
@@ -575,92 +402,7 @@ void main() {
 
       final result = await delegate.syncSubscriptionWithStore();
 
-      expect(result.isSuccess, isTrue);
       expect(result.value.outcome, SubscriptionSyncOutcome.error);
-    });
-
-    test('onSyncStateChanged: sync開始時にtrue、終了時にfalseが呼ばれる', () async {
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ),
-        ),
-      );
-      final calls = <bool>[];
-      final delegate = buildDelegate(onSyncStateChanged: calls.add);
-
-      await delegate.syncSubscriptionWithStore();
-
-      expect(calls, [true, false]);
-    });
-
-    test(
-      '月額・年額の両 productId が restored された場合 → auto-refreshスキップしてsynced(2)を返す',
-      () async {
-        when(() => mockStateService.getRawStatus()).thenAnswer(
-          (_) async => Success(
-            buildStatus(
-              planId: SubscriptionConstants.premiumMonthlyPlanId,
-              expiryDate: DateTime.now().add(const Duration(days: 15)),
-            ),
-          ),
-        );
-        when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumMonthlyProductId,
-            ),
-          );
-          purchaseStreamController.add(
-            const PurchaseResult(
-              status: PurchaseStatus.restored,
-              productId: SubscriptionConstants.premiumYearlyProductId,
-            ),
-          );
-        });
-        final delegate = buildDelegate();
-
-        final result = await delegate.syncSubscriptionWithStore();
-
-        expect(result.isSuccess, isTrue);
-        expect(result.value.outcome, SubscriptionSyncOutcome.synced);
-        expect(result.value.restoredCount, 2);
-        verifyNever(() => mockStateService.updateStatus(any()));
-      },
-    );
-
-    test('ローカルがPremium、タイムアウト後に restored が来ても集計されず降格', () async {
-      // タイムアウトを極短に設定し、delayed で遅延して emit しても間に合わないことを確認
-      when(() => mockStateService.getRawStatus()).thenAnswer(
-        (_) async => Success(
-          buildStatus(
-            planId: SubscriptionConstants.premiumMonthlyPlanId,
-            expiryDate: DateTime.now().add(const Duration(days: 15)),
-          ),
-        ),
-      );
-      when(() => mockIAP.restorePurchases()).thenAnswer((_) async {
-        // testTimeout (50ms) より長い遅延で emit → 集計されない
-        Future<void>.delayed(const Duration(milliseconds: 200)).then((_) {
-          if (!purchaseStreamController.isClosed) {
-            purchaseStreamController.add(
-              const PurchaseResult(
-                status: PurchaseStatus.restored,
-                productId: SubscriptionConstants.premiumMonthlyProductId,
-              ),
-            );
-          }
-        });
-      });
-      final delegate = buildDelegate();
-
-      final result = await delegate.syncSubscriptionWithStore();
-
-      expect(result.isSuccess, isTrue);
-      expect(result.value.outcome, SubscriptionSyncOutcome.downgradedToBasic);
     });
   });
 }


### PR DESCRIPTION
## Summary
- 起動時のサブスクリプション同期が「restoreイベントの有無」で購読の有効性を推測していた弱点を修正。iOSは**期限切れの自動更新購読でも `restored` を返す**ため、解約・期限切れユーザーがPremiumのまま残り、起動のたびに有効期限が再延長される恐れがあった。
- ネイティブの **StoreKit2 `Transaction.currentEntitlements`** から Apple 管理の実値（有効期限・返金/取消・`willAutoRenew`）を MethodChannel 経由で取得し、それを真実として降格/更新を判定するように変更。
- `SubscriptionSyncDelegate` を 3 状態契約（`Success(entitlement)` / `Success(null)`=降格根拠 / `Failure`=現状維持）で再構成。`willAutoRenew` を反映し、解約済み（`autoRenewal=false`）を `true` で誤上書きしない（取得不能時は既存値を保持）。
- 新規: `StoreKit2EntitlementHandler.swift`（Runnerターゲットに登録）、`StoreEntitlement` モデル、`IStoreEntitlementService` + 実装、サービス登録の配線。
- 旧restore方式の残骸（`storeSyncTimeout` 定数など）を削除。署名設定は Manual のまま（CI/TestFlight互換）、`project.pbxproj` の差分はファイル追加のみ。

## Test Plan
- `fvm flutter analyze` → No issues found!
- `fvm flutter test` → 全 2051 件パス（`willAutoRenew=false`→保存false / `null`→既存値保持 のケースを含む新規テスト追加）
- iOS実機ビルド成功（StoreKit2ハンドラのコンパイル確認済み）
- 手動確認（推奨）: TestFlightまたは期限切れ/解約させたSandboxで、起動時ログに `Store sync: no active entitlement, downgrading to Basic` が出てBasicへ降格すること、解約済みで設定画面の自動更新表示が誤って「あり」に戻らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * App Store との購読状態の同期がより正確に対応するようになりました。有効な自動更新購読の期限と更新状況を直接取得し、アプリの購読ステータスをリアルタイムで保つようになります。

* **バグ修正**
  * 購読同期の信頼性が向上し、プランの降格防止ロジックが強化されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dai175/smart_photo_diary/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->