### PR TITLE
fix: refresh home usage pill after upgrade from any path

### DIFF
--- a/lib/services/subscription_state_service.dart
+++ b/lib/services/subscription_state_service.dart
@@ -186,6 +186,7 @@ class SubscriptionStateService
       _subscriptionBox = await Hive.openBox<SubscriptionStatus>(
         SubscriptionConstants.hiveBoxName,
       );
+      await _emitStatusChange();
       return const Success(null);
     } catch (e) {
       log('Error refreshing status', level: LogLevel.error, error: e);

--- a/lib/services/subscription_state_service.dart
+++ b/lib/services/subscription_state_service.dart
@@ -19,7 +19,8 @@ class SubscriptionStateService
     implements ISubscriptionStateService {
   Box<SubscriptionStatus>? _subscriptionBox;
   bool _isInitialized = false;
-  Stream<SubscriptionStatus>? _statusStream;
+  final StreamController<SubscriptionStatus> _statusController =
+      StreamController<SubscriptionStatus>.broadcast();
   final ILoggingService? _loggingService;
 
   @override
@@ -163,6 +164,7 @@ class SubscriptionStateService
       }
       await _subscriptionBox!.put(SubscriptionConstants.statusKey, status);
       log('Status updated successfully', level: LogLevel.info);
+      await _emitStatusChange();
       return const Success(null);
     } catch (e) {
       log('Error updating status', level: LogLevel.error, error: e);
@@ -213,6 +215,7 @@ class SubscriptionStateService
         level: LogLevel.info,
         data: {'planId': plan.id},
       );
+      await _emitStatusChange();
       return Success(newStatus);
     } catch (e) {
       log('Error creating status', level: LogLevel.error, error: e);
@@ -250,22 +253,23 @@ class SubscriptionStateService
   }
 
   @override
-  Stream<SubscriptionStatus> get statusStream {
-    return _statusStream ??=
-        Stream.periodic(const Duration(minutes: 5), (_) async {
-              final statusResult = await getCurrentStatus();
-              return statusResult.isSuccess ? statusResult.value : null;
-            })
-            .asyncMap((statusFuture) => statusFuture)
-            .where((status) => status != null)
-            .cast<SubscriptionStatus>()
-            .asBroadcastStream();
+  Stream<SubscriptionStatus> get statusStream => _statusController.stream;
+
+  /// forcePlan などの動的上書きを適用した実効ステータスを流すため、
+  /// 永続化済みの値ではなく [getCurrentStatus] の結果を emit する。
+  Future<void> _emitStatusChange() async {
+    if (_statusController.isClosed) return;
+    final statusResult = await getCurrentStatus();
+    if (statusResult.isSuccess && !_statusController.isClosed) {
+      _statusController.add(statusResult.value);
+    }
   }
 
   @override
   Future<void> dispose() async {
     log('Disposing SubscriptionStateService...', level: LogLevel.info);
     await _subscriptionBox?.close();
+    await _statusController.close();
     _isInitialized = false;
     log('SubscriptionStateService disposed', level: LogLevel.info);
   }

--- a/lib/widgets/home_content_widget.dart
+++ b/lib/widgets/home_content_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import '../controllers/photo_selection_controller.dart';
@@ -10,6 +12,7 @@ import '../ui/design_system/app_spacing.dart';
 import '../ui/design_system/app_typography.dart';
 import '../ui/animations/micro_interactions.dart';
 import '../services/interfaces/subscription_service_interface.dart';
+import '../models/subscription_status.dart';
 import '../core/service_registration.dart';
 import '../utils/upgrade_dialog_utils.dart';
 import '../ui/components/custom_dialog.dart';
@@ -42,6 +45,7 @@ class _HomeContentWidgetState extends State<HomeContentWidget> {
   late final ISubscriptionService _subscriptionService;
   int? _remainingGenerations;
   Plan? _cachedPlan;
+  StreamSubscription<SubscriptionStatus>? _statusSub;
 
   @override
   void initState() {
@@ -50,6 +54,15 @@ class _HomeContentWidgetState extends State<HomeContentWidget> {
         widget.subscriptionService ??
         ServiceRegistration.get<ISubscriptionService>();
     _loadUsageSummary();
+    _statusSub = _subscriptionService.statusStream.listen((_) {
+      _loadUsageSummary();
+    });
+  }
+
+  @override
+  void dispose() {
+    _statusSub?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadUsageSummary() async {

--- a/test/integration/mocks/mock_services.dart
+++ b/test/integration/mocks/mock_services.dart
@@ -373,6 +373,9 @@ class TestServiceSetup {
     // Default mock behavior for SubscriptionService
     when(() => mock.isInitialized).thenReturn(true);
     when(() => mock.initialize()).thenAnswer((_) async => const Success(null));
+    when(
+      () => mock.statusStream,
+    ).thenAnswer((_) => const Stream<SubscriptionStatus>.empty());
 
     // Basic Plan default setup
     final basicPlan = BasicPlan();

--- a/test/integration/test_helpers/integration_test_helpers.dart
+++ b/test/integration/test_helpers/integration_test_helpers.dart
@@ -467,6 +467,9 @@ class IntegrationTestHelpers {
     when(
       () => mockSubscriptionService.initialize(),
     ).thenAnswer((_) async => const Success(null));
+    when(
+      () => mockSubscriptionService.statusStream,
+    ).thenAnswer((_) => const Stream<SubscriptionStatus>.empty());
     when(() => mockSubscriptionService.getCurrentStatus()).thenAnswer(
       (_) async => Success(
         SubscriptionStatus(


### PR DESCRIPTION
## Summary
- ホーム画面ヘッダーの使用量カウンター（例: `10 / 10`）が、アップグレード後に更新されない問題を修正
- 原因: `HomeContentWidget` がサブスク状態の変化を購読しておらず、`_loadUsageSummary()` が initState とヘッダーダイアログ経由のアップグレードでしか呼ばれていなかった。`IndexedStack` で State が破棄されないため、設定画面・ロック写真モーダルなど別経路でアップグレードしてもヘッダーが古い値のまま残っていた
- `SubscriptionStateService.statusStream` を、購読者ゼロのデッドコードだった5分ポーリングから `StreamController.broadcast()` の即時 emit に作り替え、状態書き込みの関所（`updateStatus` / `createStatusForPlan`）で通知するように変更
- `HomeContentWidget` が `statusStream` を購読し、どの経路のアップグレードでもヘッダーを再取得するように
- テストのモック（`mock_services.dart` / `integration_test_helpers.dart`）に `statusStream` スタブを追加

## Test Plan
- `fvm flutter test` — 全 2052 テストがパス
- `fvm flutter analyze` — No issues found!
- 手動確認: 設定画面・ロック写真モーダル・ヘッダーダイアログのいずれの経路からアップグレードしても、ホームヘッダーの使用量表示が即座に更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス向上**
  * サブスクリプション状態の更新メカニズムを改善し、より効率的でリアルタイムな反映を実現しました。

* **テスト**
  * テストモックの更新により、テストの信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->