### PR TITLE
ci: migrate iOS signing to fastlane match

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -35,10 +35,8 @@ jobs:
       - name: Verify required secrets
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          IOS_DISTRIBUTION_CERTIFICATE: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE }}
-          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
-          IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
-          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -46,10 +44,8 @@ jobs:
         run: |
           MISSING=()
           [ -z "$GEMINI_API_KEY" ] && MISSING+=("GEMINI_API_KEY")
-          [ -z "$IOS_DISTRIBUTION_CERTIFICATE" ] && MISSING+=("IOS_DISTRIBUTION_CERTIFICATE")
-          [ -z "$IOS_CERTIFICATE_PASSWORD" ] && MISSING+=("IOS_CERTIFICATE_PASSWORD")
-          [ -z "$IOS_PROVISIONING_PROFILE" ] && MISSING+=("IOS_PROVISIONING_PROFILE")
-          [ -z "$IOS_KEYCHAIN_PASSWORD" ] && MISSING+=("IOS_KEYCHAIN_PASSWORD")
+          [ -z "$MATCH_PASSWORD" ] && MISSING+=("MATCH_PASSWORD")
+          [ -z "$MATCH_DEPLOY_KEY" ] && MISSING+=("MATCH_DEPLOY_KEY")
           [ -z "$IOS_TEAM_ID" ] && MISSING+=("IOS_TEAM_ID")
           [ -z "$APP_STORE_CONNECT_API_KEY_ID" ] && MISSING+=("APP_STORE_CONNECT_API_KEY_ID")
           [ -z "$APP_STORE_CONNECT_ISSUER_ID" ] && MISSING+=("APP_STORE_CONNECT_ISSUER_ID")
@@ -60,36 +56,37 @@ jobs:
           fi
           echo "All required secrets verified"
 
-      - name: Install Apple certificate and provisioning profile
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Setup SSH for match
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE }}
-          P12_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE }}
-          KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
         run: |
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          mkdir -p ~/.ssh
+          printf '%s\n' "$MATCH_DEPLOY_KEY" > ~/.ssh/match_deploy_key
+          chmod 600 ~/.ssh/match_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          printf 'Host github.com\n  IdentityFile ~/.ssh/match_deploy_key\n  IdentitiesOnly yes\n' >> ~/.ssh/config
 
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+      - name: Sync iOS signing assets (fastlane match)
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: |
+          cd ios
+          bundle exec fastlane sync_signing
 
           echo "=== Installed certificates ==="
-          security find-identity -v -p codesigning $KEYCHAIN_PATH
+          security find-identity -v -p codesigning
           echo "=== Installed provisioning profiles ==="
-          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
-          echo "=== Xcode project signing settings ==="
-          grep -n "CODE_SIGN_STYLE\|PROVISIONING_PROFILE_SPECIFIER" ios/Runner.xcodeproj/project.pbxproj || true
+          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
 
       - name: Create ExportOptions.plist
         env:
@@ -115,7 +112,7 @@ jobs:
               <key>provisioningProfiles</key>
               <dict>
                   <key>com.focuswave.dev.smartPhotoDiary</key>
-                  <string>Smart Photo Diary App Store</string>
+                  <string>match AppStore com.focuswave.dev.smartPhotoDiary</string>
               </dict>
           </dict>
           </plist>
@@ -154,13 +151,6 @@ jobs:
         if: always()
         run: rm -f dart_defines.json
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-          working-directory: ios
-
       - name: Upload to TestFlight
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -184,7 +174,6 @@ jobs:
         if: always()
         run: |
           rm -f ios/ExportOptions.plist
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
       - name: Create release summary
         env:

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -63,19 +63,20 @@ jobs:
           bundler-cache: true
           working-directory: ios
 
-      - name: Setup SSH for match
+      - name: Install match deploy key
         env:
           MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "$MATCH_DEPLOY_KEY" > ~/.ssh/match_deploy_key
           chmod 600 ~/.ssh/match_deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          printf 'Host github.com\n  IdentityFile ~/.ssh/match_deploy_key\n  IdentitiesOnly yes\n' >> ~/.ssh/config
 
       - name: Sync iOS signing assets (fastlane match)
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          # Scope the deploy key to match's git clone only (avoids forcing all
+          # github.com SSH traffic through this read-only certs-repo key).
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/match_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
@@ -174,6 +175,7 @@ jobs:
         if: always()
         run: |
           rm -f ios/ExportOptions.plist
+          rm -f ~/.ssh/match_deploy_key
 
       - name: Create release summary
         env:

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
@@ -503,7 +503,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.focuswave.dev.smartPhotoDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Smart Photo Diary App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.focuswave.dev.smartPhotoDiary";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -683,7 +683,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
@@ -697,7 +697,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.focuswave.dev.smartPhotoDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Smart Photo Diary App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.focuswave.dev.smartPhotoDiary";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -711,7 +711,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
@@ -725,7 +725,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.focuswave.dev.smartPhotoDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Smart Photo Diary App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.focuswave.dev.smartPhotoDiary";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,4 @@
+app_identifier("com.focuswave.dev.smartPhotoDiary")
+team_id("P785AMQPKJ")
+# apple_id is intentionally omitted: signing/upload authenticate via the
+# App Store Connect API key (see Fastfile), so no Apple ID + 2FA is needed.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -4,7 +4,7 @@ platform :ios do
   # Build the App Store Connect API key once; reused by match and TestFlight
   # upload so neither needs an Apple ID + 2FA.
   def app_store_api_key
-    app_store_connect_api_key(
+    @app_store_api_key ||= app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
       key_content: ENV["APP_STORE_CONNECT_API_KEY"],

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,17 +1,41 @@
 default_platform(:ios)
 
 platform :ios do
-  desc "Upload IPA to TestFlight via App Store Connect API Key"
-  lane :upload_testflight do
-    api_key = app_store_connect_api_key(
+  # Build the App Store Connect API key once; reused by match and TestFlight
+  # upload so neither needs an Apple ID + 2FA.
+  def app_store_api_key
+    app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
       key_content: ENV["APP_STORE_CONNECT_API_KEY"],
       is_key_content_base64: true
     )
+  end
 
+  desc "CI: install App Store signing assets from the match repo (read-only)"
+  lane :sync_signing do
+    # Creates and unlocks a temporary keychain on CI runners.
+    setup_ci
+    match(
+      type: "appstore",
+      readonly: true,
+      api_key: app_store_api_key
+    )
+  end
+
+  desc "Local: create/renew the App Store cert & profile, then push to the match repo"
+  lane :renew_signing do
+    match(
+      type: "appstore",
+      readonly: false,
+      api_key: app_store_api_key
+    )
+  end
+
+  desc "Upload IPA to TestFlight via App Store Connect API Key"
+  lane :upload_testflight do
     upload_to_testflight(
-      api_key: api_key,
+      api_key: app_store_api_key,
       ipa: ENV["IPA_PATH"],
       skip_waiting_for_build_processing: true
     )

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,0 +1,23 @@
+# fastlane match configuration.
+# Certificates & profiles are stored ENCRYPTED (via MATCH_PASSWORD) in a
+# SEPARATE private git repo — never in this app repo.
+#
+# This repo is SHARED with other apps under the same Apple Developer team
+# (P785AMQPKJ): the distribution certificate is reused, only a per-app
+# provisioning profile is added. MATCH_PASSWORD MUST match the one that
+# encrypted the repo.
+#
+# SSH URL: CI authenticates with the read-only deploy key registered on
+# flowease-certs (secret MATCH_DEPLOY_KEY); locally it uses your own SSH key.
+git_url(ENV["MATCH_GIT_URL"] || "git@github.com:dai175/flowease-certs.git")
+storage_mode("git")
+
+# App Store distribution signing only (no development certs needed for deploy).
+type("appstore")
+
+app_identifier(["com.focuswave.dev.smartPhotoDiary"])
+team_id("P785AMQPKJ")
+
+# readonly is set per-lane in the Fastfile:
+#   sync_signing  -> readonly: true  (CI: fetch & install only)
+#   renew_signing -> readonly: false (local: create/renew & push to repo)


### PR DESCRIPTION
## Summary
- Migrate iOS code signing from manual base64 GitHub secrets to **fastlane match**
- Share certs/profiles via the existing **flowease-certs** repo, authenticated with the read-only **SSH deploy key** (`MATCH_DEPLOY_KEY`) — same mechanism flowease already uses
- Reuse the team's Apple Distribution certificate (`RFM348ZFF4`, valid until 2027-01-18); only a per-app provisioning profile (`match AppStore com.focuswave.dev.smartPhotoDiary`) is added
- Fastfile: add `sync_signing` (CI, readonly) and `renew_signing` (local) lanes; share the App Store Connect API key builder; keep `upload_testflight`
- ios-deploy.yml: replace the manual cert/keychain install with an SSH setup + `fastlane sync_signing`; update the ExportOptions profile name

Resolves the "iOS Distribution certificate expiring" notice: the app now signs with the match-managed certificate instead of the old manual one.

## Test Plan
- Verified locally: `bundle exec fastlane renew_signing` reused cert `RFM348ZFF4` and created the App Store profile, pushing it to flowease-certs (no new certificate created)
- Required repo secrets are set: `MATCH_PASSWORD`, `MATCH_DEPLOY_KEY`
- CI verification: trigger a release (or `workflow_dispatch`) and confirm `Setup SSH for match` → `sync_signing` → `flutter build ipa` → TestFlight upload all succeed
- After CI passes: delete the now-unused secrets `IOS_DISTRIBUTION_CERTIFICATE`, `IOS_CERTIFICATE_PASSWORD`, `IOS_PROVISIONING_PROFILE`, `IOS_KEYCHAIN_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS デプロイメント パイプラインのセキュリティと安定性を向上。署名・プロビジョニング プロセスを最新化し、API キー管理の効率化と証明書管理の統一化を実施。デプロイ前検証の強化により、リリース時のエラーリスクを軽減。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->