### PR TITLE
Use shared FocusWave signing repository

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Verify required secrets
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
@@ -44,6 +45,7 @@ jobs:
         run: |
           MISSING=()
           [ -z "$GEMINI_API_KEY" ] && MISSING+=("GEMINI_API_KEY")
+          [ -z "$MATCH_GIT_URL" ] && MISSING+=("MATCH_GIT_URL")
           [ -z "$MATCH_PASSWORD" ] && MISSING+=("MATCH_PASSWORD")
           [ -z "$MATCH_DEPLOY_KEY" ] && MISSING+=("MATCH_DEPLOY_KEY")
           [ -z "$IOS_TEAM_ID" ] && MISSING+=("IOS_TEAM_ID")
@@ -73,6 +75,7 @@ jobs:
 
       - name: Sync iOS signing assets (fastlane match)
         env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           # Scope the deploy key to match's git clone only (avoids forcing all
           # github.com SSH traffic through this read-only certs-repo key).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Key rules for quick reference:
 
 - Certs/profiles live in the shared private repo `dai175/focuswave-certs` for FocusWave apps under Apple team `P785AMQPKJ`. CI fetches them with the read-only SSH deploy key secret `MATCH_DEPLOY_KEY`, decrypted with `MATCH_PASSWORD`.
 - Lanes in `ios/fastlane/Fastfile`: `sync_signing` (CI, readonly), `renew_signing` (local), `upload_testflight`.
-- **Renew the distribution certificate** (yearly / on expiry): `cd ios && bundle exec fastlane renew_signing` (needs `MATCH_PASSWORD` + App Store Connect API key env). No manual `.p12` / base64 / Secrets work.
+- **Renew the distribution certificate** (yearly / on expiry): `cd ios && bundle exec fastlane renew_signing` (needs `MATCH_GIT_URL`, `MATCH_PASSWORD`, and App Store Connect API key env). No manual `.p12` / base64 / Secrets work.
 - **Release flow**: bump version → push tag `vX.Y.Z` → `release.yml` creates a draft → publish the draft → `ios-deploy.yml` signs + uploads to TestFlight.
 - **Gotcha**: the distribution build configs in `ios/Runner.xcodeproj/project.pbxproj` must match the match assets — `PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = "match AppStore com.focuswave.dev.smartPhotoDiary"` and `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Distribution"`. Updating `ExportOptions.plist` alone is not enough — `flutter build ipa`'s archive step uses the project settings.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Key rules for quick reference:
 
 ### iOS Code Signing (fastlane match)
 
-- Certs/profiles live in a separate private repo `dai175/flowease-certs` (shared with the Flowease app under the same Apple team `P785AMQPKJ`). CI fetches them with the read-only SSH deploy key secret `MATCH_DEPLOY_KEY`, decrypted with `MATCH_PASSWORD`.
+- Certs/profiles live in the shared private repo `dai175/focuswave-certs` for FocusWave apps under Apple team `P785AMQPKJ`. CI fetches them with the read-only SSH deploy key secret `MATCH_DEPLOY_KEY`, decrypted with `MATCH_PASSWORD`.
 - Lanes in `ios/fastlane/Fastfile`: `sync_signing` (CI, readonly), `renew_signing` (local), `upload_testflight`.
 - **Renew the distribution certificate** (yearly / on expiry): `cd ios && bundle exec fastlane renew_signing` (needs `MATCH_PASSWORD` + App Store Connect API key env). No manual `.p12` / base64 / Secrets work.
 - **Release flow**: bump version → push tag `vX.Y.Z` → `release.yml` creates a draft → publish the draft → `ios-deploy.yml` signs + uploads to TestFlight.

--- a/docs/ci_cd_guide.md
+++ b/docs/ci_cd_guide.md
@@ -59,7 +59,7 @@ CI パイプラインの通過検証。`set-deploy-sha` オプションで `DEPL
 ### iOS配布用（fastlane match）
 ```bash
 MATCH_PASSWORD                  # match リポジトリ復号用パスフレーズ
-MATCH_DEPLOY_KEY                # flowease-certs を読む SSH デプロイ鍵（秘密鍵・read-only）
+MATCH_DEPLOY_KEY                # focuswave-certs を読む SSH デプロイ鍵（秘密鍵・read-only）
 IOS_TEAM_ID                     # Apple Developer Team ID
 APP_STORE_CONNECT_API_KEY_ID    # App Store Connect API キーID
 APP_STORE_CONNECT_ISSUER_ID     # App Store Connect Issuer ID
@@ -67,7 +67,7 @@ APP_STORE_CONNECT_API_KEY       # App Store Connect API キー（.p8内容、bas
 GEMINI_API_KEY                  # Google Gemini API キー
 ```
 
-> 証明書・プロファイルは別リポジトリ `dai175/flowease-certs` に暗号化保管（fastlane match）。CI は `MATCH_DEPLOY_KEY` で取得し、ローカルの証明書更新は `cd ios && bundle exec fastlane renew_signing`。詳細は [CLAUDE.md](../CLAUDE.md) の「iOS Code Signing (fastlane match)」を参照。
+> 証明書・プロファイルは FocusWave アプリ共通の別リポジトリ `dai175/focuswave-certs` に暗号化保管（fastlane match）。CI は `MATCH_DEPLOY_KEY` で取得し、ローカルの証明書更新は `cd ios && bundle exec fastlane renew_signing`。詳細は [CLAUDE.md](../CLAUDE.md) の「iOS Code Signing (fastlane match)」を参照。
 
 ## スクリプト (`scripts/`)
 

--- a/docs/ci_cd_guide.md
+++ b/docs/ci_cd_guide.md
@@ -58,6 +58,7 @@ CI パイプラインの通過検証。`set-deploy-sha` オプションで `DEPL
 
 ### iOS配布用（fastlane match）
 ```bash
+MATCH_GIT_URL                   # focuswave-certs の SSH URL
 MATCH_PASSWORD                  # match リポジトリ復号用パスフレーズ
 MATCH_DEPLOY_KEY                # focuswave-certs を読む SSH デプロイ鍵（秘密鍵・read-only）
 IOS_TEAM_ID                     # Apple Developer Team ID

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -8,8 +8,8 @@
 # encrypted the repo.
 #
 # SSH URL: CI authenticates with the read-only deploy key registered on
-# flowease-certs (secret MATCH_DEPLOY_KEY); locally it uses your own SSH key.
-git_url(ENV["MATCH_GIT_URL"] || "git@github.com:dai175/flowease-certs.git")
+# focuswave-certs (secret MATCH_DEPLOY_KEY); locally it uses your own SSH key.
+git_url(ENV["MATCH_GIT_URL"] || "git@github.com:dai175/focuswave-certs.git")
 storage_mode("git")
 
 # App Store distribution signing only (no development certs needed for deploy).

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -7,9 +7,9 @@
 # provisioning profile is added. MATCH_PASSWORD MUST match the one that
 # encrypted the repo.
 #
-# SSH URL: CI authenticates with the read-only deploy key registered on
-# focuswave-certs (secret MATCH_DEPLOY_KEY); locally it uses your own SSH key.
-git_url(ENV["MATCH_GIT_URL"] || "git@github.com:dai175/focuswave-certs.git")
+# MATCH_GIT_URL is required. CI authenticates with the read-only deploy key
+# registered on focuswave-certs; locally it uses your own SSH key.
+git_url(ENV["MATCH_GIT_URL"])
 storage_mode("git")
 
 # App Store distribution signing only (no development certs needed for deploy).


### PR DESCRIPTION
## 概要

- fastlane match のリポジトリ URL を必須の `MATCH_GIT_URL` 設定へ統一
- GitHub Actions で `MATCH_GIT_URL` Secret を必須チェックし、署名同期ステップへ明示的に渡すよう更新
- CI/CD ドキュメントを FocusWave 共通証明書リポジトリの名称と運用内容に更新

## 背景

証明書リポジトリを `flowease-certs` から `focuswave-certs` へ改名し、同じ Apple Developer Team の FocusWave アプリで共有する構成に変更したためです。リポジトリ URL の暗黙的なフォールバックは使わず、CI・ローカルとも明示的な設定を必須にします。

## 影響

GitHub Actions の `MATCH_GIT_URL` Secret には `git@github.com:dai175/focuswave-certs.git` を登録済みです。Deploy Key と `MATCH_PASSWORD`、証明書やプロビジョニングプロファイル自体は変更しません。

## 検証

- `ruby -c ios/fastlane/Matchfile`
- workflow YAML parse
- `git diff --check`
- pre-commit hook: Flutter analyze
- pre-commit hook: secrets check